### PR TITLE
Folia support

### DIFF
--- a/build-logic/src/main/kotlin/platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/platform-conventions.gradle.kts
@@ -33,8 +33,7 @@ tasks {
     listOf(
       "org.owasp.html",
       "org.spongepowered.configurate",
-      "org.yaml.snakeyaml",
-      "com.github.benmanes.caffeine"
+      "org.yaml.snakeyaml"
     ).forEach(::reloc)
   }
   val copyJar = register("copyJar", CopyFile::class) {

--- a/build-logic/src/main/kotlin/platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/platform-conventions.gradle.kts
@@ -34,6 +34,7 @@ tasks {
       "org.owasp.html",
       "org.spongepowered.configurate",
       "org.yaml.snakeyaml",
+      "com.github.benmanes.caffeine"
     ).forEach(::reloc)
   }
   val copyJar = register("copyJar", CopyFile::class) {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,7 +10,9 @@ minecraft {
 
 dependencies {
   api(projects.squaremapApi)
-
+  api(libs.caffeine) {
+    exclude("com.google.errorprone")
+  }
   api(libs.guice) {
     exclude("com.google.guava") // provided by minecraft
   }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,9 +10,6 @@ minecraft {
 
 dependencies {
   api(projects.squaremapApi)
-  api(libs.caffeine) {
-    exclude("com.google.errorprone")
-  }
   api(libs.guice) {
     exclude("com.google.guava") // provided by minecraft
   }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/inject/SquaremapModulesBuilder.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/inject/SquaremapModulesBuilder.java
@@ -15,6 +15,7 @@ import xyz.jpenilla.squaremap.common.inject.module.PlatformModule;
 import xyz.jpenilla.squaremap.common.inject.module.VanillaChunkSnapshotProviderFactoryModule;
 import xyz.jpenilla.squaremap.common.inject.module.VanillaRegionFileDirectoryResolverModule;
 import xyz.jpenilla.squaremap.common.task.render.RenderFactory;
+import xyz.jpenilla.squaremap.common.util.EntityScheduler;
 import xyz.jpenilla.squaremap.common.util.SquaremapJarAccess;
 
 import static java.util.Objects.requireNonNull;
@@ -28,6 +29,7 @@ public final class SquaremapModulesBuilder {
     private boolean vanillaChunkSnapshotProviderFactory;
     private @Nullable Class<? extends MapWorldInternal.Factory<?>> mapWorldFactoryClass;
     private Class<? extends SquaremapJarAccess> squaremapJarAccess = SquaremapJarAccess.JarFromCodeSource.class;
+    private Class<? extends EntityScheduler> entitySchedulerClass = EntityScheduler.NoneEntityScheduler.class;
 
     private SquaremapModulesBuilder(final SquaremapPlatform platform) {
         this.platform = platform;
@@ -54,6 +56,11 @@ public final class SquaremapModulesBuilder {
         return this;
     }
 
+    public SquaremapModulesBuilder entityScheduler(final Class<? extends EntityScheduler> entitySchedulerClass) {
+        this.entitySchedulerClass = entitySchedulerClass;
+        return this;
+    }
+
     public SquaremapModulesBuilder withModules(final Module... modules) {
         this.extraModules.addAll(Arrays.asList(modules));
         return this;
@@ -74,7 +81,7 @@ public final class SquaremapModulesBuilder {
 
         final List<Module> baseModules = List.of(
             new ApiModule(),
-            new PlatformModule(this.platform, this.platformClass, this.squaremapJarAccess),
+            new PlatformModule(this.platform, this.platformClass, this.squaremapJarAccess, this.entitySchedulerClass),
             new FactoryModuleBuilder().build(RenderFactory.class),
             new FactoryModuleBuilder().build(this.mapWorldFactoryClass)
         );

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/inject/module/PlatformModule.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/inject/module/PlatformModule.java
@@ -5,6 +5,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.common.SquaremapPlatform;
+import xyz.jpenilla.squaremap.common.util.EntityScheduler;
 import xyz.jpenilla.squaremap.common.util.SquaremapJarAccess;
 
 @DefaultQualifier(NonNull.class)
@@ -12,15 +13,18 @@ public final class PlatformModule extends AbstractModule {
     private final @Nullable SquaremapPlatform platform;
     private final @Nullable Class<? extends SquaremapPlatform> platformClass;
     private final Class<? extends SquaremapJarAccess> jarAccess;
+    private final Class<? extends EntityScheduler> entitySchedulerClass;
 
     public PlatformModule(
         final @Nullable SquaremapPlatform platform,
         final @Nullable Class<? extends SquaremapPlatform> platformClass,
-        final Class<? extends SquaremapJarAccess> jarAccess
+        final Class<? extends SquaremapJarAccess> jarAccess,
+        final Class<? extends EntityScheduler> entitySchedulerClass
     ) {
         this.platform = platform;
         this.platformClass = platformClass;
         this.jarAccess = jarAccess;
+        this.entitySchedulerClass = entitySchedulerClass;
     }
 
     @Override
@@ -35,5 +39,8 @@ public final class PlatformModule extends AbstractModule {
 
         this.bind(SquaremapJarAccess.class)
             .to(this.jarAccess);
+
+        this.bind(EntityScheduler.class)
+            .to(this.entitySchedulerClass);
     }
 }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
@@ -1,5 +1,6 @@
 package xyz.jpenilla.squaremap.common.task.render;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -12,14 +13,15 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StainedGlassBlock;
@@ -40,6 +42,7 @@ import xyz.jpenilla.squaremap.common.data.ChunkCoordinate;
 import xyz.jpenilla.squaremap.common.data.Image;
 import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.data.RegionCoordinate;
+import xyz.jpenilla.squaremap.common.util.ChunkHashMapKey;
 import xyz.jpenilla.squaremap.common.util.Colors;
 import xyz.jpenilla.squaremap.common.util.Numbers;
 import xyz.jpenilla.squaremap.common.util.Util;
@@ -52,14 +55,12 @@ public abstract class AbstractRender implements Runnable {
     private final ExecutorService executorService;
     private final Executor executor;
     private final Supplier<ChunkSnapshotProvider> createChunkSnapshotProvider;
-    private ChunkSnapshotProvider chunkSnapshotProvider;
+    private final @Nullable Map<Thread, BiomeColors> biomeColors;
+    private ChunkSnapshotManager chunks;
     private volatile @MonotonicNonNull Thread thread;
     protected volatile State state = State.RUNNING;
-
     protected final MapWorldInternal mapWorld;
     protected final ServerLevel level;
-
-    protected final @Nullable Map<Thread, BiomeColors> biomeColors;
 
     protected final AtomicInteger processedChunks = new AtomicInteger(0);
     protected final AtomicInteger processedRegions = new AtomicInteger(0);
@@ -83,10 +84,14 @@ public abstract class AbstractRender implements Runnable {
         this.executor = new RenderWorkerExecutor(workerPool, this::running);
         this.level = mapWorld.serverLevel();
         this.createChunkSnapshotProvider = () -> chunkSnapshotProviderFactory.createChunkSnapshotProvider(this.level);
-        this.chunkSnapshotProvider = this.createChunkSnapshotProvider.get();
+        this.chunks = this.createChunkSnapshotManager();
         this.biomeColors = this.mapWorld.config().MAP_BIOMES
             ? new ConcurrentHashMap<>()
             : null; // this should be null if we are not mapping biomes
+    }
+
+    private int maximumActiveChunkRequests() {
+        return ((ThreadPoolExecutor) this.executorService).getCorePoolSize() * 512;
     }
 
     protected abstract void render();
@@ -168,8 +173,20 @@ public abstract class AbstractRender implements Runnable {
         return this.processedRegions.get();
     }
 
-    protected final void resetChunkSnapshotProvider() {
-        this.chunkSnapshotProvider = this.createChunkSnapshotProvider.get();
+    protected final void clearCaches() {
+        this.chunks = this.createChunkSnapshotManager();
+        if (this.biomeColors != null) {
+            this.biomeColors.clear();
+        }
+    }
+
+    private ChunkSnapshotManager createChunkSnapshotManager() {
+        return new ChunkSnapshotManager(
+            this.createChunkSnapshotProvider.get(),
+            this.maximumActiveChunkRequests(),
+            this.mapWorld.config().MAP_BIOMES_BLEND > 0,
+            this::running
+        );
     }
 
     public final void restartProgressLogger() {
@@ -188,7 +205,7 @@ public abstract class AbstractRender implements Runnable {
         final int startZ = region.getChunkZ();
         final List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (int chunkX = startX; chunkX < startX + 32; chunkX++) {
-            futures.add(this.mapChunkColumnFuture(image, chunkX, startZ));
+            futures.add(this.mapChunkColumn(image, chunkX, startZ));
         }
         for (final CompletableFuture<Void> future : futures) {
             try {
@@ -204,85 +221,92 @@ public abstract class AbstractRender implements Runnable {
         }
     }
 
-    protected final CompletableFuture<Void> mapSingleChunkFuture(final Image image, final int chunkX, final int chunkZ) {
-        final Function<Throwable, @Nullable Void> handleError = thr -> {
-            Logging.logger().warn("Exception mapping chunk at [{}, {}] in {}", chunkX, chunkZ, this.mapWorld.identifier().asString(), thr);
-            return null;
-        };
-
-        return CompletableFuture.runAsync(() -> this.mapSingleChunk(image, chunkX, chunkZ), this.executor).exceptionally(handleError);
-    }
-
-    protected final CompletableFuture<Void> mapChunkColumnFuture(final Image image, final int chunkX, final int startChunkZ) {
-        final Function<Throwable, @Nullable Void> handleError = thr -> {
-            Logging.logger().warn("Exception mapping chunk column starting at [{}, {}] in {}", chunkX, startChunkZ, this.mapWorld.identifier().asString(), thr);
-            return null;
-        };
-
-        return CompletableFuture.runAsync(() -> this.mapChunkColumn(image, chunkX, startChunkZ), this.executor).exceptionally(handleError);
-    }
-
-    private void mapSingleChunk(final Image image, final int chunkX, final int chunkZ) {
-        int[] lastY = new int[16];
-
-        @Nullable ChunkSnapshot chunk;
-
-        // try scanning south row of northern chunk to get proper yDiff
-        chunk = this.chunkSnapshot(chunkX, chunkZ - 1);
-        if (chunk != null) {
-            lastY = this.getLastYFromBottomRow(chunk);
-        }
-
-        // scan the chunk itself
-        chunk = this.chunkSnapshot(chunkX, chunkZ);
-        if (chunk != null) {
-            this.scanChunk(image, lastY, chunk);
-        }
+    protected final CompletableFuture<Void> mapSingleChunk(final Image image, final int chunkX, final int chunkZ) {
+        final CompletableFuture<@Nullable ChunkSnapshot> northChunk = this.chunks.snapshotDirect(new ChunkPos(chunkX, chunkZ - 1));
+        final CompletableFuture<@Nullable ChunkSnapshot> chunkFuture = this.chunks.snapshot(new ChunkPos(chunkX, chunkZ));
 
         // queue up the southern chunk in case it was stored with improper yDiff
         // https://github.com/pl3xgaming/Pl3xMap/issues/15
+        final CompletableFuture<@Nullable ChunkSnapshot> southChunk;
         final int down = chunkZ + 1;
         if (Numbers.chunkToRegion(chunkZ) == Numbers.chunkToRegion(down)) {
-            chunk = this.chunkSnapshot(chunkX, down);
-            if (chunk != null) {
-                this.scanTopRow(image, lastY, chunk);
-            }
+            southChunk = this.chunks.snapshot(new ChunkPos(chunkX, down));
         } else {
             // chunk belongs to a different region, add to queue
             this.mapWorld.chunkModified(new ChunkCoordinate(chunkX, down));
+            southChunk = CompletableFuture.completedFuture(null);
         }
 
-        this.processedChunks.incrementAndGet();
-    }
-
-    private void mapChunkColumn(final Image image, final int chunkX, final int startChunkZ) {
-        int[] lastY = new int[16];
-        for (int chunkZ = startChunkZ; chunkZ < startChunkZ + 32; chunkZ++) {
+        return CompletableFuture.allOf(northChunk, chunkFuture, southChunk).thenRunAsync(() -> {
             if (!this.running()) {
                 return;
             }
+            int[] lastY = new int[16];
+
+            // try scanning south row of northern chunk to get proper yDiff
+            final @Nullable ChunkSnapshot north = northChunk.join();
+            if (north != null) {
+                lastY = this.getLastYFromBottomRow(north);
+            }
+
+            // scan the chunk itself
+            final @Nullable ChunkSnapshot chunk = chunkFuture.join();
+            if (chunk != null) {
+                this.scanChunk(image, lastY, chunk);
+            }
+
+            final @Nullable ChunkSnapshot south = southChunk.join();
+            if (south != null) {
+                this.scanTopRow(image, lastY, south);
+            }
+
+            this.processedChunks.incrementAndGet();
+        }, this.executor).exceptionally(thr -> {
+            Logging.logger().warn("Exception mapping chunk at [{}, {}] in {}", chunkX, chunkZ, this.mapWorld.identifier().asString(), thr);
+            return null;
+        });
+    }
+
+    private static final Object TOP_CHUNK = new Object();
+
+    protected final CompletableFuture<Void> mapChunkColumn(final Image image, final int chunkX, final int startChunkZ) {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+
+        final CompletableFuture<@Nullable ChunkSnapshot> topChunkFuture = this.chunks.snapshotDirect(new ChunkPos(chunkX, startChunkZ - 1));
+        futures.add(topChunkFuture.thenApply($ -> TOP_CHUNK));
+
+        for (int chunkZ = startChunkZ; chunkZ < startChunkZ + 32; chunkZ++) {
             if (!this.mapWorld.visibilityLimit().shouldRenderChunk(chunkX, chunkZ)) {
                 // skip rendering this chunk in the chunk column - it's outside the visibility limit
                 // (this chunk was already excluded from the chunk count, so not incrementing that is on purpose)
                 continue;
             }
+            futures.add(this.chunks.snapshot(new ChunkPos(chunkX, chunkZ)));
+        }
 
-            @Nullable ChunkSnapshot chunk;
-            if (chunkZ == startChunkZ) {
-                // this is the top line of the image, we need to
-                // scan the bottom line of the region to the north
-                // in order to get the correct lastY for shading
-                chunk = this.chunkSnapshot(chunkX, chunkZ - 1);
-                if (chunk != null) {
-                    lastY = this.getLastYFromBottomRow(chunk);
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenRunAsync(() -> {
+            if (!this.running()) {
+                return;
+            }
+            final int[] lastY = new int[16];
+            for (final CompletableFuture<?> future : futures) {
+                final Object result = future.join();
+                if (result == TOP_CHUNK) {
+                    final @Nullable ChunkSnapshot topChunk = topChunkFuture.join();
+                    if (topChunk != null) {
+                        System.arraycopy(this.getLastYFromBottomRow(topChunk), 0, lastY, 0, lastY.length);
+                    }
+                } else if (result instanceof ChunkSnapshot snapshot) {
+                    this.scanChunk(image, lastY, snapshot);
+                    this.processedChunks.incrementAndGet();
+                } else {
+                    this.processedChunks.incrementAndGet();
                 }
             }
-            chunk = this.chunkSnapshot(chunkX, chunkZ);
-            if (chunk != null) {
-                this.scanChunk(image, lastY, chunk);
-            }
-            this.processedChunks.incrementAndGet();
-        }
+        }, this.executor).exceptionally(thr -> {
+            Logging.logger().warn("Exception mapping chunk column starting at [{}, {}] in {}", chunkX, startChunkZ, this.mapWorld.identifier().asString(), thr);
+            return null;
+        });
     }
 
     private void scanChunk(final Image image, final int[] lastY, final ChunkSnapshot chunk) {
@@ -380,7 +404,7 @@ public abstract class AbstractRender implements Runnable {
         int color = this.mapWorld.getMapColor(state);
 
         if (this.biomeColors != null) {
-            color = this.biomeColors.computeIfAbsent(Thread.currentThread(), $ -> new BiomeColors(this.mapWorld, this.chunkSnapshotProvider))
+            color = this.biomeColors.computeIfAbsent(Thread.currentThread(), $ -> new BiomeColors(this.mapWorld, this.chunks))
                 .modifyColorFromBiome(color, chunk, mutablePos);
         }
 
@@ -515,20 +539,6 @@ public abstract class AbstractRender implements Runnable {
         return Colors.shade(color, colorOffset);
     }
 
-    private @Nullable ChunkSnapshot chunkSnapshot(final int x, final int z) {
-        final CompletableFuture<ChunkSnapshot> future = this.chunkSnapshotProvider.asyncSnapshot(x, z, false);
-        for (int failures = 1; !future.isDone(); ++failures) {
-            if (!this.running()) {
-                return null;
-            }
-            try {
-                future.get(Math.min(50, failures), TimeUnit.MILLISECONDS);
-            } catch (final InterruptedException | TimeoutException | ExecutionException ignore) {
-            }
-        }
-        return future.join();
-    }
-
     private static ExecutorService createRenderWorkerPool(final MapWorldInternal world) {
         return Util.newFixedThreadPool(
             getThreads(world.config().MAX_RENDER_THREADS),
@@ -552,6 +562,107 @@ public abstract class AbstractRender implements Runnable {
         try {
             Thread.sleep(ms);
         } catch (final InterruptedException ignore) {
+        }
+    }
+
+    public static final class ChunkSnapshotManager {
+        private final ChunkSnapshotProvider chunkSnapshotProvider;
+        private final int capacity;
+        private final Map<ChunkHashMapKey, CompletableFuture<@Nullable ChunkSnapshot>> active;
+        private final Long2ObjectLinkedOpenHashMap<CompletableFuture<@Nullable ChunkSnapshot>> cache;
+        private final boolean biomeBlend;
+        private final BooleanSupplier running;
+        private final ReentrantLock lock;
+
+        public ChunkSnapshotManager(
+            final ChunkSnapshotProvider chunkSnapshotProvider,
+            final int capacity,
+            final boolean biomeBlend,
+            final BooleanSupplier running
+        ) {
+            this.chunkSnapshotProvider = chunkSnapshotProvider;
+            this.capacity = capacity;
+            this.active = new ConcurrentHashMap<>(capacity);
+            this.cache = new Long2ObjectLinkedOpenHashMap<>(capacity);
+            this.biomeBlend = biomeBlend;
+            this.running = running;
+            this.lock = new ReentrantLock();
+        }
+
+        // requests neighbors when biomes are mapped
+        public CompletableFuture<@Nullable ChunkSnapshot> snapshot(final ChunkPos chunkPos) {
+            if (this.biomeBlend) {
+                final int x = chunkPos.x;
+                final int z = chunkPos.z;
+
+                final List<CompletableFuture<@Nullable ChunkSnapshot>> futures = List.of(
+                    this.snapshotDirect(new ChunkPos(x - 1, z - 1)),
+                    this.snapshotDirect(new ChunkPos(x - 1, z)),
+                    this.snapshotDirect(new ChunkPos(x - 1, z + 1)),
+                    this.snapshotDirect(new ChunkPos(x, z - 1)),
+                    this.snapshotDirect(new ChunkPos(x, z + 1)),
+                    this.snapshotDirect(new ChunkPos(x + 1, z - 1)),
+                    this.snapshotDirect(new ChunkPos(x + 1, z)),
+                    this.snapshotDirect(new ChunkPos(x + 1, z + 1))
+                );
+
+                final CompletableFuture<@Nullable ChunkSnapshot> thisChunk = this.snapshotDirect(chunkPos);
+                return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenCompose($ -> thisChunk);
+            }
+            return this.snapshotDirect(chunkPos);
+        }
+
+        // only requests the specific chunk
+        public CompletableFuture<@Nullable ChunkSnapshot> snapshotDirect(final ChunkPos chunkPos) {
+            final long chunkKey = chunkPos.toLong();
+
+            final @Nullable CompletableFuture<@Nullable ChunkSnapshot> active = this.active.get(key(chunkKey));
+            if (active != null) {
+                return active;
+            }
+
+            this.lock.lock();
+            try {
+                final @Nullable CompletableFuture<@Nullable ChunkSnapshot> done = this.cache.getAndMoveToFirst(chunkKey);
+                if (done != null) {
+                    return done;
+                }
+            } finally {
+                this.lock.unlock();
+            }
+
+            for (int failures = 1; this.active.size() >= this.capacity; ++failures) {
+                if (!this.running.getAsBoolean()) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                final boolean interrupted = Thread.interrupted();
+                Thread.yield();
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(Math.min(10, failures)));
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            return this.active.computeIfAbsent(key(chunkKey), key -> {
+                final CompletableFuture<@Nullable ChunkSnapshot> future = this.chunkSnapshotProvider.asyncSnapshot(chunkPos.x, chunkPos.z, false);
+                future.whenComplete(($$, $$$) -> {
+                    this.lock.lock();
+                    try {
+                        if (this.cache.size() >= this.capacity) {
+                            this.cache.removeLast();
+                        }
+                        this.cache.putAndMoveToFirst(chunkKey, future);
+                        this.active.remove(key);
+                    } finally {
+                        this.lock.unlock();
+                    }
+                });
+                return future;
+            });
+        }
+
+        private static ChunkHashMapKey key(final long key) {
+            return new ChunkHashMapKey(key);
         }
     }
 

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
@@ -43,12 +43,12 @@ import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.data.RegionCoordinate;
 import xyz.jpenilla.squaremap.common.util.ChunkHashMapKey;
 import xyz.jpenilla.squaremap.common.util.Colors;
+import xyz.jpenilla.squaremap.common.util.ConcurrentFIFOLoadingCache;
 import xyz.jpenilla.squaremap.common.util.Numbers;
 import xyz.jpenilla.squaremap.common.util.Util;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshot;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshotProvider;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshotProviderFactory;
-import xyz.jpenilla.squaremap.common.util.ConcurrentFIFOLoadingCache;
 
 @DefaultQualifier(NonNull.class)
 public abstract class AbstractRender implements Runnable {
@@ -566,6 +566,8 @@ public abstract class AbstractRender implements Runnable {
     }
 
     public static final class ChunkSnapshotManager {
+        private static final int MAXIMUM_CAPACITY = 2048;
+
         private final ChunkSnapshotProvider chunkSnapshotProvider;
         private final int maximumActiveRequests;
         private final ConcurrentFIFOLoadingCache<ChunkHashMapKey, CompletableFuture<@Nullable ChunkSnapshot>> cache;
@@ -583,8 +585,8 @@ public abstract class AbstractRender implements Runnable {
             this.chunkSnapshotProvider = chunkSnapshotProvider;
             this.maximumActiveRequests = maximumActiveRequests;
             this.cache = new ConcurrentFIFOLoadingCache<>(
-                10 * maximumActiveRequests,
-                8 * maximumActiveRequests,
+                MAXIMUM_CAPACITY,
+                (int) (MAXIMUM_CAPACITY * 0.8),
                 this::load
             );
             this.biomeBlend = biomeBlend;

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
@@ -628,17 +628,19 @@ public abstract class AbstractRender implements Runnable {
             final int x = chunkPos.x;
             final int z = chunkPos.z;
 
-            this.snapshotDirect(new ChunkPos(x - 1, z - 1));
-            this.snapshotDirect(new ChunkPos(x, z - 1));
-            this.snapshotDirect(new ChunkPos(x + 1, z + 1));
-            this.snapshotDirect(new ChunkPos(x - 1, z));
-            this.snapshotDirect(new ChunkPos(x + 1, z));
-            this.snapshotDirect(new ChunkPos(x - 1, z + 1));
-            this.snapshotDirect(new ChunkPos(x, z + 1));
-            this.snapshotDirect(new ChunkPos(x + 1, z - 1));
+            final List<CompletableFuture<@Nullable ChunkSnapshot>> neighborFutures = List.of(
+                this.snapshotDirect(new ChunkPos(x - 1, z - 1)),
+                this.snapshotDirect(new ChunkPos(x, z - 1)),
+                this.snapshotDirect(new ChunkPos(x + 1, z + 1)),
+                this.snapshotDirect(new ChunkPos(x - 1, z)),
+                this.snapshotDirect(new ChunkPos(x + 1, z)),
+                this.snapshotDirect(new ChunkPos(x - 1, z + 1)),
+                this.snapshotDirect(new ChunkPos(x, z + 1)),
+                this.snapshotDirect(new ChunkPos(x + 1, z - 1))
+            );
 
-            // return CompletableFuture.allOf(neighborFutures.toArray(CompletableFuture[]::new)).thenCompose($ -> future);
-            return future;
+            return CompletableFuture.allOf(neighborFutures.toArray(CompletableFuture[]::new)).thenCompose($ -> future);
+            //return future;
         }
 
         // only requests the specific chunk

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/BackgroundRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/BackgroundRender.java
@@ -61,7 +61,7 @@ public final class BackgroundRender extends AbstractRender {
             final Image image = new Image(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX);
 
             final CompletableFuture<?>[] chunkFutures = chunksToRenderInRegion.stream()
-                .map(coord -> this.mapSingleChunkFuture(image, coord.x(), coord.z()))
+                .map(coord -> this.mapSingleChunk(image, coord.x(), coord.z()))
                 .toArray(CompletableFuture<?>[]::new);
 
             regionFutures.add(CompletableFuture.allOf(chunkFutures).thenRun(() -> {
@@ -80,10 +80,7 @@ public final class BackgroundRender extends AbstractRender {
             Logging.logger().error("Exception executing background render", ex);
         }
 
-        if (this.biomeColors != null) {
-            this.biomeColors.clear();
-        }
-        this.resetChunkSnapshotProvider();
+        this.clearCaches();
 
         chunks.forEach(this.mapWorld::chunkModified);
 

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/RadiusRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/RadiusRender.java
@@ -102,7 +102,7 @@ public final class RadiusRender extends AbstractRender {
             final Image image = new Image(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX);
             final List<CompletableFuture<Void>> chunkFutures = new ArrayList<>();
             for (final ChunkCoordinate chunkCoord : chunkCoords) {
-                chunkFutures.add(this.mapSingleChunkFuture(image, chunkCoord.x(), chunkCoord.z()));
+                chunkFutures.add(this.mapSingleChunk(image, chunkCoord.x(), chunkCoord.z()));
             }
             try {
                 CompletableFuture.allOf(chunkFutures.toArray(CompletableFuture[]::new)).get();

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/ChunkHashMapKey.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/ChunkHashMapKey.java
@@ -1,0 +1,40 @@
+package xyz.jpenilla.squaremap.common.util;
+
+import it.unimi.dsi.fastutil.HashCommon;
+import net.minecraft.world.level.ChunkPos;
+
+public final class ChunkHashMapKey implements Comparable<ChunkHashMapKey> {
+    public final long key;
+
+    public ChunkHashMapKey(final long key) {
+        this.key = key;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) HashCommon.mix(this.key);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof final ChunkHashMapKey other)) {
+            return false;
+        }
+
+        return this.key == other.key;
+    }
+
+    @Override
+    public int compareTo(final ChunkHashMapKey other) {
+        return Long.compare(this.key, other.key);
+    }
+
+    @Override
+    public String toString() {
+        return new ChunkPos(this.key).toString();
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/ChunkHashMapKey.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/ChunkHashMapKey.java
@@ -10,6 +10,10 @@ public final class ChunkHashMapKey implements Comparable<ChunkHashMapKey> {
         this.key = key;
     }
 
+    public ChunkHashMapKey(final ChunkPos pos) {
+        this(pos.toLong());
+    }
+
     @Override
     public int hashCode() {
         return (int) HashCommon.mix(this.key);

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/ConcurrentFIFOLoadingCache.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/ConcurrentFIFOLoadingCache.java
@@ -1,0 +1,66 @@
+package xyz.jpenilla.squaremap.common.util;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class ConcurrentFIFOLoadingCache<K, V> {
+    private final int maximumCapacity;
+    private final int evictUntil;
+    private final Function<K, V> loader;
+    // lookup map
+    private final Map<K, V> map;
+    // FIFO eviction queue
+    private final Queue<K> queue;
+
+    public ConcurrentFIFOLoadingCache(
+        final int maximumCapacity,
+        final int evictUntil,
+        final Function<K, V> loader
+    ) {
+        if (maximumCapacity <= evictUntil) {
+            throw new IllegalArgumentException("maximumCapacity must be larger than evictUntil (%s <= %s)".formatted(maximumCapacity, evictUntil));
+        }
+        this.maximumCapacity = maximumCapacity;
+        this.evictUntil = evictUntil;
+        this.loader = loader;
+        this.map = new ConcurrentHashMap<>(maximumCapacity + Runtime.getRuntime().availableProcessors());
+        this.queue = new ConcurrentLinkedQueue<>();
+    }
+
+    public V get(final K key) {
+        final @Nullable V cached = this.map.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        return this.loadValue(key);
+    }
+
+    private V loadValue(final K key) {
+        final V load = this.loader.apply(key);
+        final @Nullable V prevValue = this.map.putIfAbsent(key, load);
+        if (prevValue != null) {
+            // lost race to load entry
+            return prevValue;
+        }
+        this.queue.offer(key);
+        this.maybeEvictEntries();
+        return load;
+    }
+
+    private void maybeEvictEntries() {
+        if (this.map.size() > this.maximumCapacity) {
+            while (this.map.size() > this.evictUntil) {
+                final @Nullable K remove = this.queue.poll();
+                if (remove != null) {
+                    this.map.remove(remove);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/ConcurrentFIFOLoadingCache.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/ConcurrentFIFOLoadingCache.java
@@ -55,11 +55,10 @@ public final class ConcurrentFIFOLoadingCache<K, V> {
         if (this.map.size() > this.maximumCapacity) {
             while (this.map.size() > this.evictUntil) {
                 final @Nullable K remove = this.queue.poll();
-                if (remove != null) {
-                    this.map.remove(remove);
-                } else {
+                if (remove == null) {
                     break;
                 }
+                this.map.remove(remove);
             }
         }
     }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/EntityScheduler.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/EntityScheduler.java
@@ -1,0 +1,30 @@
+package xyz.jpenilla.squaremap.common.util;
+
+import com.google.inject.Inject;
+import net.minecraft.world.entity.Entity;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import xyz.jpenilla.squaremap.common.command.Commander;
+
+@DefaultQualifier(NonNull.class)
+public interface EntityScheduler {
+    void scheduleFor(Entity entity, Runnable task);
+
+    void scheduleFor(Commander commander, Runnable task);
+
+    final class NoneEntityScheduler implements EntityScheduler {
+        @Inject
+        private NoneEntityScheduler() {
+        }
+
+        @Override
+        public void scheduleFor(final Entity entity, final Runnable task) {
+            task.run();
+        }
+
+        @Override
+        public void scheduleFor(final Commander commander, final Runnable task) {
+            task.run();
+        }
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshot.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshot.java
@@ -1,7 +1,7 @@
 package xyz.jpenilla.squaremap.common.util.chunksnapshot;
 
 import java.util.EnumMap;
-import net.minecraft.Util;
+import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.ChunkPos;
@@ -34,18 +34,20 @@ public interface ChunkSnapshot extends LevelHeightAccessor, BiomeManager.NoiseBi
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     static ChunkSnapshot snapshot(final LevelChunk chunk, final boolean biomesOnly) {
-        final int sectionCount = chunk.getSectionsCount();
+        final LevelHeightAccessor heightAccessor = LevelHeightAccessor.create(chunk.getMinBuildHeight(), chunk.getHeight());
+        final int sectionCount = heightAccessor.getSectionsCount();
         final LevelChunkSection[] sections = chunk.getSections();
         final PalettedContainer<BlockState>[] states = new PalettedContainer[sectionCount];
         final PalettedContainer<Holder<Biome>>[] biomes = new PalettedContainer[sectionCount];
 
         final boolean[] empty = new boolean[sectionCount];
-        final Heightmap heightmap = new Heightmap(chunk, Heightmap.Types.WORLD_SURFACE);
+        Map<Heightmap.Types, HeightmapSnapshot> heightmaps = ChunkSnapshotImpl.EMPTY_HEIGHTMAPS;
         if (!biomesOnly) {
             if (!chunk.hasPrimedHeightmap(Heightmap.Types.WORLD_SURFACE)) {
                 throw new IllegalStateException("Expected WORLD_SURFACE heightmap to be present, but it wasn't! " + chunk.getPos());
             }
-            heightmap.setRawData(chunk, Heightmap.Types.WORLD_SURFACE, chunk.getOrCreateHeightmapUnprimed(Heightmap.Types.WORLD_SURFACE).getRawData());
+            heightmaps = new EnumMap<>(ChunkSnapshotImpl.EMPTY_HEIGHTMAPS);
+            heightmaps.put(Heightmap.Types.WORLD_SURFACE, new HeightmapSnapshot(chunk, heightAccessor, Heightmap.Types.WORLD_SURFACE));
 
             for (int i = 0; i < sectionCount; i++) {
                 final boolean sectionEmpty = sections[i].hasOnlyAir();
@@ -66,10 +68,10 @@ public interface ChunkSnapshot extends LevelHeightAccessor, BiomeManager.NoiseBi
         }
 
         return new ChunkSnapshotImpl(
-            LevelHeightAccessor.create(chunk.getMinBuildHeight(), chunk.getHeight()),
+            heightAccessor,
             states,
             biomes,
-            Util.make(new EnumMap<>(Heightmap.Types.class), map -> map.put(Heightmap.Types.WORLD_SURFACE, heightmap)),
+            heightmaps,
             empty,
             chunk.getLevel().dimensionType(),
             chunk.getPos()

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshot.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshot.java
@@ -34,7 +34,6 @@ public interface ChunkSnapshot extends LevelHeightAccessor, BiomeManager.NoiseBi
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     static ChunkSnapshot snapshot(final LevelChunk chunk, final boolean biomesOnly) {
-        // AsyncCatcher.catchOp("Chunk Snapshot");
         final int sectionCount = chunk.getSectionsCount();
         final LevelChunkSection[] sections = chunk.getSections();
         final PalettedContainer<BlockState>[] states = new PalettedContainer[sectionCount];

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshotImpl.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshotImpl.java
@@ -1,5 +1,6 @@
 package xyz.jpenilla.squaremap.common.util.chunksnapshot;
 
+import java.util.EnumMap;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -24,7 +25,7 @@ record ChunkSnapshotImpl(
     LevelHeightAccessor heightAccessor,
     PalettedContainer<BlockState>[] states,
     PalettedContainer<Holder<Biome>>[] biomes,
-    Map<Heightmap.Types, Heightmap> heightmaps,
+    Map<Heightmap.Types, HeightmapSnapshot> heightmaps,
     boolean[] emptySections,
     DimensionType dimensionType,
     ChunkPos pos
@@ -34,6 +35,7 @@ record ChunkSnapshotImpl(
         Blocks.AIR.defaultBlockState(),
         PalettedContainer.Strategy.SECTION_STATES
     );
+    static final EnumMap<Heightmap.Types, HeightmapSnapshot> EMPTY_HEIGHTMAPS = new EnumMap<>(Heightmap.Types.class);
 
     @Override
     public BlockState getBlockState(final BlockPos pos) {
@@ -63,7 +65,7 @@ record ChunkSnapshotImpl(
 
     @Override
     public int getHeight(final Heightmap.Types type, final int x, final int z) {
-        final Heightmap heightmap = this.heightmaps.get(type);
+        final HeightmapSnapshot heightmap = this.heightmaps.get(type);
         if (heightmap == null) {
             throw new RuntimeException("Missing heightmaps " + type);
         }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshotProvider.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/ChunkSnapshotProvider.java
@@ -1,23 +1,11 @@
 package xyz.jpenilla.squaremap.common.util.chunksnapshot;
 
 import java.util.concurrent.CompletableFuture;
-import net.minecraft.world.level.ChunkPos;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 
 @DefaultQualifier(NonNull.class)
 public interface ChunkSnapshotProvider {
-    CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(
-        int x,
-        int z,
-        boolean biomesOnly
-    );
-
-    default CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(
-        final ChunkPos chunkPos,
-        final boolean biomesOnly
-    ) {
-        return this.asyncSnapshot(chunkPos.x, chunkPos.z, biomesOnly);
-    }
+    CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(int x, int z);
 }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/HeightmapSnapshot.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/HeightmapSnapshot.java
@@ -1,0 +1,38 @@
+package xyz.jpenilla.squaremap.common.util.chunksnapshot;
+
+import net.minecraft.util.BitStorage;
+import net.minecraft.util.Mth;
+import net.minecraft.util.SimpleBitStorage;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.Heightmap;
+
+final class HeightmapSnapshot {
+    private final BitStorage data;
+    private final LevelHeightAccessor heightAccessor;
+
+    HeightmapSnapshot(
+        final ChunkAccess chunk,
+        final LevelHeightAccessor heightAccessor,
+        final Heightmap.Types heightmapType
+    ) {
+        this.data = new SimpleBitStorage(
+            Mth.ceillog2(heightAccessor.getHeight() + 1),
+            256,
+            chunk.getOrCreateHeightmapUnprimed(heightmapType).getRawData().clone()
+        );
+        this.heightAccessor = heightAccessor;
+    }
+
+    public int getFirstAvailable(final int x, final int z) {
+        return this.getFirstAvailable(getIndex(x, z));
+    }
+
+    private int getFirstAvailable(final int index) {
+        return this.data.get(index) + this.heightAccessor.getMinBuildHeight();
+    }
+
+    private static int getIndex(final int x, final int z) {
+        return x + z * 16;
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/VanillaChunkSnapshotProvider.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/chunksnapshot/VanillaChunkSnapshotProvider.java
@@ -22,17 +22,13 @@ record VanillaChunkSnapshotProvider(ServerLevel level) implements ChunkSnapshotP
     private static final ResourceLocation FULL = BuiltInRegistries.CHUNK_STATUS.getKey(ChunkStatus.FULL);
 
     @Override
-    public CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(
-        final int x,
-        final int z,
-        final boolean biomesOnly
-    ) {
+    public CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(final int x, final int z) {
         return CompletableFuture.supplyAsync(() -> {
             final @Nullable LevelChunk chunk = fullChunkIfGenerated(this.level, x, z);
             if (chunk == null || chunk.isEmpty()) {
                 return null;
             }
-            return ChunkSnapshot.snapshot(chunk, biomesOnly);
+            return ChunkSnapshot.snapshot(chunk, false);
         }, this.level.getServer());
     }
 

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -26,7 +26,6 @@ versions:
     cardinalComponents: 5.2.1
     guice: 5.1.0
     forge: 1.20.1-47.0.0
-    caffeine: 3.1.6
 
     # buildSrc
     indra: 3.0.1
@@ -81,11 +80,6 @@ dependencies:
         group: net.kyori
         name: examination-string
         version: { ref: examination }
-
-    caffeine:
-        group: com.github.ben-manes.caffeine
-        name: caffeine
-        version: { ref: caffeine }
 
     cloudCore:
         group: cloud.commandframework

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -26,6 +26,7 @@ versions:
     cardinalComponents: 5.2.1
     guice: 5.1.0
     forge: 1.20.1-47.0.0
+    caffeine: 3.1.6
 
     # buildSrc
     indra: 3.0.1
@@ -80,6 +81,11 @@ dependencies:
         group: net.kyori
         name: examination-string
         version: { ref: examination }
+
+    caffeine:
+        group: com.github.ben-manes.caffeine
+        name: caffeine
+        version: { ref: caffeine }
 
     cloudCore:
         group: cloud.commandframework

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -5,7 +5,7 @@ metadata:
 
 plugins:
     org.spongepowered.gradle.plugin: 2.1.1
-    xyz.jpenilla.run-paper: 2.0.1
+    xyz.jpenilla.run-paper: 2.1.0
     net.minecrell.plugin-yml.bukkit: 0.5.3
     io.papermc.hangar-publish-plugin: 0.0.3
 

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -3,7 +3,6 @@ import io.papermc.hangarpublishplugin.model.Platforms
 plugins {
   id("platform-conventions")
   id("io.papermc.paperweight.userdev")
-  id("net.minecrell.plugin-yml.bukkit")
   id("xyz.jpenilla.run-paper")
   id("io.papermc.hangar-publish-plugin")
 }
@@ -11,7 +10,7 @@ plugins {
 val minecraftVersion = libs.versions.minecraft
 
 dependencies {
-  paperweight.paperDevBundle(minecraftVersion.map { "$it-R0.1-SNAPSHOT" })
+  paperweight.devBundle("dev.folia", minecraftVersion.map { "$it-R0.1-SNAPSHOT" }.get())
 
   implementation(projects.squaremapCommon)
 
@@ -43,8 +42,15 @@ tasks {
     outputJar.set(productionJarLocation(minecraftVersion))
   }
   processResources {
+    val props = mapOf(
+      "version" to project.version,
+      "website" to providers.gradleProperty("githubUrl").get(),
+      "description" to project.description,
+      "apiVersion" to "'" + minecraftVersion.get().take(4) + "'",
+    )
+    inputs.properties(props)
     filesMatching("plugin.yml") {
-      filter { it.replace("1.20", "'1.20'") }
+      expand(props)
     }
   }
 }
@@ -53,13 +59,7 @@ squaremapPlatform {
   productionJar.set(tasks.reobfJar.flatMap { it.outputJar })
 }
 
-bukkit {
-  main = "xyz.jpenilla.squaremap.paper.SquaremapPaperBootstrap"
-  name = rootProject.name
-  apiVersion = "1.20"
-  website = providers.gradleProperty("githubUrl").get()
-  authors = listOf("jmp")
-}
+runPaper.folia.registerTask()
 
 hangarPublish.publications.register("plugin") {
   version.set(project.version as String)

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -73,3 +73,7 @@ hangarPublish.publications.register("plugin") {
     platformVersions.add(minecraftVersion)
   }
 }
+
+modrinth {
+  loaders.set(listOf("paper", "folia"))
+}

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 val minecraftVersion = libs.versions.minecraft
 
 dependencies {
-  paperweight.devBundle("dev.folia", minecraftVersion.map { "$it-R0.1-SNAPSHOT" }.get())
+  paperweight.foliaDevBundle(minecraftVersion.map { "$it-R0.1-SNAPSHOT" })
 
   implementation(projects.squaremapCommon)
 

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/SquaremapPaper.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/SquaremapPaper.java
@@ -3,12 +3,17 @@ package xyz.jpenilla.squaremap.paper;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
+import io.papermc.paper.threadedregions.RegionizedServerInitEvent;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Server;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitTask;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -18,9 +23,12 @@ import xyz.jpenilla.squaremap.common.SquaremapCommon;
 import xyz.jpenilla.squaremap.common.SquaremapPlatform;
 import xyz.jpenilla.squaremap.common.task.UpdatePlayers;
 import xyz.jpenilla.squaremap.common.task.UpdateWorldData;
+import xyz.jpenilla.squaremap.common.util.ExceptionLoggingScheduledThreadPoolExecutor;
+import xyz.jpenilla.squaremap.common.util.Util;
 import xyz.jpenilla.squaremap.paper.listener.MapUpdateListeners;
 import xyz.jpenilla.squaremap.paper.listener.WorldLoadListener;
 import xyz.jpenilla.squaremap.paper.network.PaperNetworking;
+import xyz.jpenilla.squaremap.paper.util.Folia;
 
 @DefaultQualifier(NonNull.class)
 @Singleton
@@ -31,10 +39,11 @@ public final class SquaremapPaper implements SquaremapPlatform {
     private final JavaPlugin plugin;
     private final Server server;
     private @MonotonicNonNull Squaremap api;
-    private @Nullable BukkitTask updateWorldData;
-    private @Nullable BukkitTask updatePlayers;
+    private @Nullable ScheduledFuture<?> updateWorldData;
+    private @Nullable ScheduledFuture<?> updatePlayers;
     private @Nullable MapUpdateListeners mapUpdateListeners;
     private @Nullable WorldLoadListener worldLoadListener;
+    private @Nullable ScheduledExecutorService taskPool;
 
     @Inject
     private SquaremapPaper(
@@ -57,7 +66,18 @@ public final class SquaremapPaper implements SquaremapPlatform {
         this.server.getServicesManager().register(Squaremap.class, this.api, this.plugin, ServicePriority.Normal);
         this.networking.register();
         new Metrics(this.plugin, 13571); // https://bstats.org/plugin/bukkit/squaremap/13571
-        this.server.getScheduler().runTask(this.plugin, this.common::updateCheck);
+        if (Folia.FOLIA) {
+            this.server.getPluginManager().registerEvents(new FoliaInitListener(), this.plugin);
+        } else {
+            this.server.getScheduler().runTask(this.plugin, this.common::updateCheck);
+        }
+    }
+
+    public final class FoliaInitListener implements Listener {
+        @EventHandler
+        public void handle(final RegionizedServerInitEvent event) {
+            SquaremapPaper.this.server.getAsyncScheduler().runNow(SquaremapPaper.this.plugin, $ -> SquaremapPaper.this.common.updateCheck());
+        }
     }
 
     void onDisable() {
@@ -76,25 +96,34 @@ public final class SquaremapPaper implements SquaremapPlatform {
         this.mapUpdateListeners = this.injector.getInstance(MapUpdateListeners.class);
         this.mapUpdateListeners.register();
 
-        this.updatePlayers = this.server.getScheduler()
-            .runTaskTimer(this.plugin, this.injector.getInstance(UpdatePlayers.class), 20, 20);
+        this.taskPool = new ExceptionLoggingScheduledThreadPoolExecutor(1, Util.squaremapThreadFactory("tasks"));
 
-        this.updateWorldData = this.server.getScheduler()
-            .runTaskTimer(this.plugin, this.injector.getInstance(UpdateWorldData.class), 0, 20 * 5);
+        this.updatePlayers = this.taskPool.scheduleAtFixedRate(
+            this.injector.getInstance(UpdatePlayers.class),
+            1,
+            1,
+            TimeUnit.SECONDS
+        );
+        this.updateWorldData = this.taskPool.scheduleAtFixedRate(
+            this.injector.getInstance(UpdateWorldData.class),
+            0,
+            5,
+            TimeUnit.SECONDS
+        );
     }
 
     @Override
     public void stopCallback() {
         if (this.updateWorldData != null) {
             if (!this.updateWorldData.isCancelled()) {
-                this.updateWorldData.cancel();
+                this.updateWorldData.cancel(false);
             }
             this.updateWorldData = null;
         }
 
         if (this.updatePlayers != null) {
             if (!this.updatePlayers.isCancelled()) {
-                this.updatePlayers.cancel();
+                this.updatePlayers.cancel(false);
             }
             this.updatePlayers = null;
         }
@@ -109,7 +138,9 @@ public final class SquaremapPaper implements SquaremapPlatform {
             this.worldLoadListener = null;
         }
 
-        this.server.getScheduler().cancelTasks(this.plugin);
+        if (this.taskPool != null) {
+            Util.shutdownExecutor(this.taskPool, TimeUnit.MILLISECONDS, 500);
+        }
     }
 
     @Override

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/SquaremapPaperBootstrap.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/SquaremapPaperBootstrap.java
@@ -14,6 +14,7 @@ import xyz.jpenilla.squaremap.common.inject.SquaremapModulesBuilder;
 import xyz.jpenilla.squaremap.common.util.Util;
 import xyz.jpenilla.squaremap.paper.data.PaperMapWorld;
 import xyz.jpenilla.squaremap.paper.inject.module.PaperModule;
+import xyz.jpenilla.squaremap.paper.util.PaperEntityScheduler;
 
 @DefaultQualifier(NonNull.class)
 public final class SquaremapPaperBootstrap extends JavaPlugin {
@@ -37,6 +38,7 @@ public final class SquaremapPaperBootstrap extends JavaPlugin {
         final Injector injector = Guice.createInjector(
             SquaremapModulesBuilder.forPlatform(SquaremapPaper.class)
                 .mapWorldFactory(PaperMapWorld.Factory.class)
+                .entityScheduler(PaperEntityScheduler.class)
                 .withModule(new PaperModule(this))
                 .build()
         );

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/command/PaperCommands.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/command/PaperCommands.java
@@ -1,16 +1,26 @@
 package xyz.jpenilla.squaremap.paper.command;
 
+import cloud.commandframework.Command;
 import cloud.commandframework.CommandManager;
+import cloud.commandframework.CommandTree;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.bukkit.arguments.selector.SinglePlayerSelector;
 import cloud.commandframework.bukkit.parsers.location.Location2D;
 import cloud.commandframework.bukkit.parsers.location.Location2DArgument;
 import cloud.commandframework.bukkit.parsers.selector.SinglePlayerSelectorArgument;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
+import cloud.commandframework.execution.CommandResult;
 import cloud.commandframework.paper.PaperCommandManager;
+import cloud.commandframework.services.State;
+import cloud.commandframework.types.tuples.Pair;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import org.bukkit.entity.Player;
@@ -26,6 +36,7 @@ import xyz.jpenilla.squaremap.common.command.exception.CommandCompleted;
 import xyz.jpenilla.squaremap.common.config.Messages;
 import xyz.jpenilla.squaremap.common.util.Components;
 import xyz.jpenilla.squaremap.paper.util.CraftBukkitReflection;
+import xyz.jpenilla.squaremap.paper.util.Folia;
 
 @DefaultQualifier(NonNull.class)
 @Singleton
@@ -43,7 +54,7 @@ public final class PaperCommands implements PlatformCommands {
         try {
             mgr = new PaperCommandManager<>(
                 this.plugin,
-                CommandExecutionCoordinator.simpleCoordinator(),
+                ExecutionCoordinator::new,
                 PaperCommander::from,
                 commander -> ((PaperCommander) commander).sender()
             );
@@ -94,5 +105,58 @@ public final class PaperCommands implements PlatformCommands {
         }
 
         return CraftBukkitReflection.serverPlayer(targetPlayer);
+    }
+
+    private static final class ExecutionCoordinator<C> extends CommandExecutionCoordinator<C> {
+        private final @Nullable ReentrantLock executionLock;
+
+        ExecutionCoordinator(final CommandTree<C> commandTree) {
+            super(commandTree);
+            this.executionLock = Folia.FOLIA ? new ReentrantLock() : null;
+        }
+
+        @Override
+        public CompletableFuture<CommandResult<C>> coordinateExecution(
+            final CommandContext<C> commandContext,
+            final Queue<String> input
+        ) {
+            final CompletableFuture<CommandResult<C>> completableFuture = new CompletableFuture<>();
+            try {
+                final Pair<@Nullable Command<C>, @Nullable Exception> pair =
+                    this.getCommandTree().parse(commandContext, input);
+                if (pair.getSecond() != null) {
+                    completableFuture.completeExceptionally(pair.getSecond());
+                } else {
+                    final Command<C> command = Objects.requireNonNull(pair.getFirst());
+                    if (this.getCommandTree().getCommandManager().postprocessContext(commandContext, command) == State.ACCEPTED) {
+                        if (this.executionLock != null) {
+                            this.executionLock.lock();
+                        }
+                        try {
+                            command.getCommandExecutionHandler().executeFuture(commandContext).get();
+                        } catch (final java.util.concurrent.ExecutionException exception) {
+                            Throwable cause = exception.getCause();
+                            if (cause instanceof CommandExecutionException) {
+                                completableFuture.completeExceptionally(cause);
+                            } else {
+                                completableFuture.completeExceptionally(new CommandExecutionException(cause, commandContext));
+                            }
+                        } catch (final CommandExecutionException exception) {
+                            completableFuture.completeExceptionally(exception);
+                        } catch (final Exception exception) {
+                            completableFuture.completeExceptionally(new CommandExecutionException(exception, commandContext));
+                        } finally {
+                            if (this.executionLock != null) {
+                                this.executionLock.unlock();
+                            }
+                        }
+                    }
+                    completableFuture.complete(new CommandResult<>(commandContext));
+                }
+            } catch (final Exception e) {
+                completableFuture.completeExceptionally(e);
+            }
+            return completableFuture;
+        }
     }
 }

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/data/PaperMapWorld.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/data/PaperMapWorld.java
@@ -2,6 +2,9 @@ package xyz.jpenilla.squaremap.paper.data;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import net.minecraft.server.level.ServerLevel;
 import org.bukkit.Server;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,10 +16,13 @@ import xyz.jpenilla.squaremap.common.data.DirectoryProvider;
 import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.task.UpdateMarkers;
 import xyz.jpenilla.squaremap.common.task.render.RenderFactory;
+import xyz.jpenilla.squaremap.common.util.ExceptionLoggingScheduledThreadPoolExecutor;
+import xyz.jpenilla.squaremap.common.util.Util;
+import xyz.jpenilla.squaremap.paper.util.Folia;
 
 @DefaultQualifier(NonNull.class)
 public final class PaperMapWorld extends MapWorldInternal {
-    private final BukkitTask updateMarkersTask;
+    private final MarkerTaskHandler markerTaskHandler;
 
     @AssistedInject
     private PaperMapWorld(
@@ -29,18 +35,63 @@ public final class PaperMapWorld extends MapWorldInternal {
     ) {
         super(level, renderFactory, directoryProvider, configManager);
 
-        this.updateMarkersTask = server.getScheduler()
-            .runTaskTimer(plugin, new UpdateMarkers(this), 20 * 5, 20L * this.config().MARKER_API_UPDATE_INTERVAL_SECONDS);
+        if (Folia.FOLIA) {
+            this.markerTaskHandler = new FoliaMarkerTaskHandler(level);
+        } else {
+            this.markerTaskHandler = new PaperMarkerTaskHandler(plugin, server);
+        }
     }
 
     @Override
     public void shutdown() {
-        this.updateMarkersTask.cancel();
+        this.markerTaskHandler.shutdown();
         super.shutdown();
     }
 
     public interface Factory extends MapWorldInternal.Factory<PaperMapWorld> {
         @Override
         PaperMapWorld create(ServerLevel level);
+    }
+
+    private interface MarkerTaskHandler {
+        void shutdown();
+    }
+
+    private final class PaperMarkerTaskHandler implements MarkerTaskHandler {
+        private final BukkitTask updateMarkersTask;
+
+        private PaperMarkerTaskHandler(
+            final JavaPlugin plugin,
+            final Server server
+        ) {
+            this.updateMarkersTask = server.getScheduler()
+                .runTaskTimer(plugin, new UpdateMarkers(PaperMapWorld.this), 20 * 5, 20L * PaperMapWorld.this.config().MARKER_API_UPDATE_INTERVAL_SECONDS);
+        }
+
+        @Override
+        public void shutdown() {
+            this.updateMarkersTask.cancel();
+        }
+    }
+
+    private final class FoliaMarkerTaskHandler implements MarkerTaskHandler {
+        private final ScheduledExecutorService markerThread;
+        private final ScheduledFuture<?> updateMarkersTask;
+
+        private FoliaMarkerTaskHandler(final ServerLevel level) {
+            this.markerThread = new ExceptionLoggingScheduledThreadPoolExecutor(1, Util.squaremapThreadFactory("markers", level));
+            this.updateMarkersTask = this.markerThread.scheduleAtFixedRate(
+                new UpdateMarkers(PaperMapWorld.this),
+                5,
+                PaperMapWorld.this.config().MARKER_API_UPDATE_INTERVAL_SECONDS,
+                TimeUnit.SECONDS
+            );
+        }
+
+        @Override
+        public void shutdown() {
+            this.updateMarkersTask.cancel(false);
+            Util.shutdownExecutor(this.markerThread, TimeUnit.MILLISECONDS, 100);
+        }
     }
 }

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/Folia.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/Folia.java
@@ -1,0 +1,16 @@
+package xyz.jpenilla.squaremap.paper.util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import xyz.jpenilla.squaremap.common.util.ReflectionUtil;
+
+public final class Folia {
+    public static final boolean FOLIA;
+
+    static {
+        final @Nullable Class<?> regionizedServerCls = ReflectionUtil.findClass("io.papermc.paper.threadedregions.RegionizedServer");
+        FOLIA = regionizedServerCls != null;
+    }
+
+    private Folia() {
+    }
+}

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/PaperEntityScheduler.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/PaperEntityScheduler.java
@@ -1,0 +1,50 @@
+package xyz.jpenilla.squaremap.paper.util;
+
+import com.google.inject.Inject;
+import net.minecraft.world.entity.Entity;
+import org.bukkit.Server;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import xyz.jpenilla.squaremap.common.command.Commander;
+import xyz.jpenilla.squaremap.common.util.EntityScheduler;
+import xyz.jpenilla.squaremap.paper.command.PaperCommander;
+
+@DefaultQualifier(NonNull.class)
+public final class PaperEntityScheduler implements EntityScheduler {
+    private final Server server;
+    private final JavaPlugin plugin;
+
+    @Inject
+    private PaperEntityScheduler(final Server server, final JavaPlugin plugin) {
+        this.server = server;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void scheduleFor(final Entity entity, final Runnable task) {
+        if (Folia.FOLIA) {
+            entity.getBukkitEntity().getScheduler().execute(this.plugin, task, null, 0L);
+        } else {
+            task.run();
+        }
+    }
+
+    @Override
+    public void scheduleFor(final Commander commander, final Runnable task) {
+        if (!Folia.FOLIA) {
+            task.run();
+            return;
+        }
+        final CommandSender sender = ((PaperCommander) commander).sender();
+        if (sender instanceof org.bukkit.entity.Entity entity) {
+            entity.getScheduler().execute(this.plugin, task, null, 0L);
+        } else if (sender instanceof BlockCommandSender block) {
+            this.server.getRegionScheduler().execute(this.plugin, block.getBlock().getLocation(), task);
+        } else {
+            this.server.getGlobalRegionScheduler().execute(this.plugin, task);
+        }
+    }
+}

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProvider.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProvider.java
@@ -2,20 +2,29 @@ package xyz.jpenilla.squaremap.paper.util.chunksnapshot;
 
 import ca.spottedleaf.concurrentutil.executor.standard.PrioritisedExecutor;
 import io.papermc.paper.chunk.system.ChunkSystem;
+import io.papermc.paper.util.TickThread;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.ImposterProtoChunk;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Server;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshot;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshotProvider;
+import xyz.jpenilla.squaremap.paper.util.Folia;
 
 @DefaultQualifier(NonNull.class)
-record PaperChunkSnapshotProvider(ServerLevel level) implements ChunkSnapshotProvider {
+record PaperChunkSnapshotProvider(
+    ServerLevel level,
+    Server server,
+    JavaPlugin plugin
+) implements ChunkSnapshotProvider {
     @Override
     public CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(
         final int x,
@@ -40,7 +49,7 @@ record PaperChunkSnapshotProvider(ServerLevel level) implements ChunkSnapshotPro
                 load::complete
             );
             return load;
-        }, this.level.getServer()).thenCompose(chunkFuture -> chunkFuture.thenApplyAsync(chunk -> {
+        }, this.executor(x, z)).thenCompose(chunkFuture -> chunkFuture.thenApplyAsync(chunk -> {
             if (chunk == null || !chunk.getStatus().isOrAfter(ChunkStatus.FULL)) {
                 return null;
             }
@@ -51,6 +60,25 @@ record PaperChunkSnapshotProvider(ServerLevel level) implements ChunkSnapshotPro
                 return ChunkSnapshot.snapshot(levelChunk, biomesOnly);
             }
             return null;
-        }, this.level.getServer()));
+        }, this.executor(x, z)));
+    }
+
+    private Executor executor(final int x, final int z) {
+        if (!Folia.FOLIA) {
+            return this.level.getServer();
+        }
+        return task -> {
+            if (TickThread.isTickThreadFor(this.level, x, z)) {
+                task.run();
+                return;
+            }
+            this.server.getRegionScheduler().execute(
+                this.plugin,
+                this.level.getWorld(),
+                x,
+                z,
+                task
+            );
+        };
     }
 }

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProvider.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProvider.java
@@ -26,11 +26,7 @@ record PaperChunkSnapshotProvider(
     JavaPlugin plugin
 ) implements ChunkSnapshotProvider {
     @Override
-    public CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(
-        final int x,
-        final int z,
-        final boolean biomesOnly
-    ) {
+    public CompletableFuture<@Nullable ChunkSnapshot> asyncSnapshot(final int x, final int z) {
         return CompletableFuture.supplyAsync(() -> {
             final @Nullable ChunkAccess existing = this.level.getChunkIfLoadedImmediately(x, z);
             if (existing != null && existing.getStatus().isOrAfter(ChunkStatus.FULL)) {
@@ -57,7 +53,7 @@ record PaperChunkSnapshotProvider(
                 chunk = imposter.getWrapped();
             }
             if (chunk instanceof LevelChunk levelChunk && !levelChunk.isEmpty()) {
-                return ChunkSnapshot.snapshot(levelChunk, biomesOnly);
+                return ChunkSnapshot.snapshot(levelChunk, false);
             }
             return null;
         }, this.executor(x, z)));

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProviderFactory.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/util/chunksnapshot/PaperChunkSnapshotProviderFactory.java
@@ -3,6 +3,8 @@ package xyz.jpenilla.squaremap.paper.util.chunksnapshot;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.minecraft.server.level.ServerLevel;
+import org.bukkit.Server;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshotProvider;
@@ -11,12 +13,17 @@ import xyz.jpenilla.squaremap.common.util.chunksnapshot.ChunkSnapshotProviderFac
 @DefaultQualifier(NonNull.class)
 @Singleton
 public final class PaperChunkSnapshotProviderFactory implements ChunkSnapshotProviderFactory {
+    private final Server server;
+    private final JavaPlugin plugin;
+
     @Inject
-    private PaperChunkSnapshotProviderFactory() {
+    private PaperChunkSnapshotProviderFactory(final Server server, final JavaPlugin plugin) {
+        this.server = server;
+        this.plugin = plugin;
     }
 
     @Override
     public ChunkSnapshotProvider createChunkSnapshotProvider(final ServerLevel level) {
-        return new PaperChunkSnapshotProvider(level);
+        return new PaperChunkSnapshotProvider(level, this.server, this.plugin);
     }
 }

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: squaremap
+version: $version
+main: xyz.jpenilla.squaremap.paper.SquaremapPaperBootstrap
+description: $description
+authors:
+ - jmp
+website: $website
+api-version: $apiVersion
+folia-supported: true


### PR DESCRIPTION
Due to Folia not having mid-tick task execution, a significant refactor was needed to ensure performance parity.

In my testing across M2 Pro and a 32-core Xeon machine, these changes ended up slightly reducing average render times on Paper and allowed for a comparable level of performance on Folia.

[Test jar](https://files.jpenilla.xyz/squaremap-paper-mc1.20.1-1.1.15-SNAPSHOT+d733046.jar) (Paper/Folia)