### PR TITLE
[RFC] Disable HTML in map markers?

### DIFF
--- a/common/src/main/resources/web/css/styles.css
+++ b/common/src/main/resources/web/css/styles.css
@@ -64,6 +64,10 @@ div.leaflet-control-layers.coordinates {
   line-height: 14px;
   height: 30px;
 }
+div.leaflet-popup-content-wrapper,
+div.leaflet-tooltip {
+  white-space: pre-line
+}
 #sidebar {
   display: flex;
   flex-flow: column;

--- a/common/src/main/resources/web/js/modules/util/Markers.js
+++ b/common/src/main/resources/web/js/modules/util/Markers.js
@@ -11,23 +11,24 @@ class Marker {
     }
     init() {
         if (this.popup != null) {
+            const msg = document.createTextNode(this.popup);
             if (this.popup_sticky) {
                 this.marker.on('click', (e) => {
                     L.popup({
                         direction: this.opts.pop("tooltip_direction", "top")
                     })
                     .setLatLng(P.toLatLng(P.coordinates.coords.x, P.coordinates.coords.z))
-                    .setContent(this.popup)
+                    .setContent(msg)
                     .openOn(P.map);
                 });
             } else {
-                this.marker.bindPopup(() => this.popup, {
-                    direction: this.opts.pop("tooltip_direction", "top")
+                this.marker.bindPopup(() => msg, {
+                    direction: this.opts.pop("tooltip_direction", "top"),
                 });
             }
         }
         if (this.tooltip != null) {
-            this.marker.bindTooltip(() => this.tooltip, {
+            this.marker.bindTooltip(() => document.createTextNode(this.tooltip), {
                 direction: this.opts.pop("tooltip_direction", "top"),
                 sticky: this.tooltip_sticky
             });


### PR DESCRIPTION
I am looking to migrate from the now-defunct Overviewer. In Overviewer, map markers were "self-service:" they could safely be auto-generated from in-game signs and other entities.

At present, squaremap markers permit HTML content. This design choice requires us to permit marker edits by trusted users only. For example, `squaremap-signs` requires the [`squaremap.signs.admin`](https://github.com/jpenilla/squaremap-addons/blob/bfaa98f3317d01c90e9cc1c2aecf4a0e3805ed8c/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/listener/SignListener.java#L50C43-L50C43) permission. If permissions are granted to untrusted users, they could inject `<script>` and other dangerous (or nuisance) elements into the Leaflet page.

This PR demonstrates a simple modification to the Leaflet JavaScript that can safely block HTML elements. This PR is not ready to merge as-is because there are a number of design issues, including:

- [ ] **API compatibility**: this feature is API-breaking and would have to be gated behind a config option.

- [ ] **Styles**: HTML-based styles in plugins like squaremap-signs must be replaced with CSS. API might be required for safely conveying styles from plugins back to squaremap. Leaflet text nodes may need to be wrapped in a `<div>` for this purpose.

- [ ] **Additional fields**: review is needed to determine other Leaflet fields which might contain user-generated content.

Are these changes a good idea? If so, what else am I missing?