### PR TITLE
common: don't cleanup icons on unregister

### DIFF
--- a/common/src/main/java/xyz/jpenilla/squaremap/common/IconRegistry.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/IconRegistry.java
@@ -51,11 +51,6 @@ public final class IconRegistry implements Registry<BufferedImage> {
         if (removed == null) {
             throw noImageRegistered(key);
         }
-        try {
-            Files.delete(this.directory.resolve(key.getKey() + ".png"));
-        } catch (IOException e) {
-            throw failedToDeleteImage(key, e);
-        }
     }
 
     @Override
@@ -81,10 +76,6 @@ public final class IconRegistry implements Registry<BufferedImage> {
 
     private static IllegalArgumentException failedToCreateRegistry(final IOException e) {
         return new IllegalArgumentException("Failed to setup icon registry", e);
-    }
-
-    private static IllegalArgumentException failedToDeleteImage(final Key key, final IOException e) {
-        return new IllegalArgumentException(String.format("Failed to delete image for key '%s'", key.getKey()), e);
     }
 
     private static IllegalArgumentException failedToWriteImage(final Key key, final IOException e) {


### PR DESCRIPTION
In previous versions, icons files were removed from the web directory when they were unregistered via
`IconRegistry.unregister()`. Icons are unregistered when plugins are shut down or removed.

When an external web server is in use, map tiles remain available to clients after the game server has stopped—but registered icons do not. The removed icons result in ugly "broken link" images on clients.

Since icons are generally quite small, and are in most cases seldomly swapped out, leaving unused icon files is probably not a big deal. Skip the removal of `images/icon/registered` and all icon files. Old icon files are overwritten as necessary with new ones.

Closes #114
