### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/api/src/main/java/xyz/jpenilla/squaremap/api/WorldIdentifier.java
+++ b/api/src/main/java/xyz/jpenilla/squaremap/api/WorldIdentifier.java
@@ -8,7 +8,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  *
  * <p>Mirrors Minecraft's {@code ResourceLocation}. This means the same rules apply regarding allowed characters.</p>
  *
- * @see <a href="https://minecraft.fandom.com/wiki/Resource_location#Legal_characters">https://minecraft.fandom.com/wiki/Resource_location#Legal_characters</a>
+ * @see <a href="https://minecraft.wiki/w/Resource_location#Legal_characters">https://minecraft.wiki/w/Resource_location#Legal_characters</a>
  */
 @DefaultQualifier(NonNull.class)
 public interface WorldIdentifier {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.