### PR TITLE
web: display block coordinates in Leaflet

### DIFF
--- a/common/src/main/resources/web/js/modules/UICoordinates.js
+++ b/common/src/main/resources/web/js/modules/UICoordinates.js
@@ -13,8 +13,8 @@ class UICoordinates {
                 return coords;
             },
             update: function (html, point) {
-                this.x = point == null ? "---" : Math.round(point.x);
-                this.z = point == null ? "---" : Math.round(point.y);
+                this.x = point == null ? "---" : Math.floor(point.x);
+                this.z = point == null ? "---" : Math.floor(point.y);
                 if (html != null) {
                     this._coords.innerHTML = html
                         .replace(/{x}/g, this.x)


### PR DESCRIPTION

> ![(animation) world coordinates vs block coordinates](https://github.com/jpenilla/squaremap/assets/3526918/937dadaa-db80-4381-884e-488ab2b0b3d1)
>
> (animation) Leaflet displays world coordinates instead of block coordinates. This causes the displayed coordinates to change mid-block. The block coordinates of the selected block are verified as X=752, Z=-1461.

At sufficiently high `zoom.extra` levels, it is possible to unambiguously select a single block with the mouse cursor. The current "Coordinates" control will display different values depending on which quadrant of the block the user has selected. This is because the display is rounded to the nearest world coordinate instead of the nearest **block coordinate**.

For planning builds, block coordinates are more useful than world coordinates. Block coordinates are the XYZ world coordinates of the northwest corner of the block. Block coordinates are calculated from world coordinates by flooring. Block coordinates are available in the game client's F3 screen.

This patch only changes the rounding that is displayed to web users. Internal coordinate frames are left undisturbed.