### PR TITLE
Avoid writing players json to disk when possible

### DIFF
--- a/common/src/main/java/xyz/jpenilla/squaremap/common/SquaremapCommon.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/SquaremapCommon.java
@@ -87,12 +87,13 @@ public final class SquaremapCommon {
     private void stop() {
         if (Config.HTTPD_ENABLED) {
             IntegratedServer.stopServer();
-            if (!Config.FLUSH_JSON_IMMEDIATELY) {
-                this.jsonCache.flush();
-            }
         }
         this.platform.stopCallback();
         this.worldManager.shutdown();
+        if (Config.HTTPD_ENABLED && !Config.FLUSH_JSON_IMMEDIATELY) {
+            this.jsonCache.flush();
+        }
+        this.jsonCache.clear();
     }
 
     public void reload(final Audience audience) {

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/config/Config.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/config/Config.java
@@ -69,11 +69,13 @@ public final class Config extends AbstractConfig {
     public static boolean HTTPD_ENABLED = true;
     public static String HTTPD_BIND = "0.0.0.0";
     public static int HTTPD_PORT = 8080;
+    public static boolean FLUSH_JSON_IMMEDIATELY = false;
 
     private static void internalWebServerSettings() {
         HTTPD_ENABLED = config.getBoolean("settings.internal-webserver.enabled", HTTPD_ENABLED);
         HTTPD_BIND = config.getString("settings.internal-webserver.bind", HTTPD_BIND);
         HTTPD_PORT = config.getInt("settings.internal-webserver.port", HTTPD_PORT);
+        FLUSH_JSON_IMMEDIATELY = config.getBoolean("settings.internal-webserver.flush-json-immediately", FLUSH_JSON_IMMEDIATELY);
     }
 
     public static boolean UI_COORDINATES_ENABLED = true;

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/IntegratedServer.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/IntegratedServer.java
@@ -19,11 +19,13 @@ import xyz.jpenilla.squaremap.common.data.DirectoryProvider;
 
 public final class IntegratedServer {
     private static Undertow SERVER;
+    private static JsonCache CACHE;
 
     private IntegratedServer() {
     }
 
-    public static void startServer(final DirectoryProvider directoryProvider) {
+    public static void startServer(final DirectoryProvider directoryProvider, final JsonCache jsonCache) {
+        CACHE = jsonCache;
         try {
             SERVER = buildUndertow(createResourceHandler(directoryProvider));
             SERVER.start();
@@ -46,6 +48,11 @@ public final class IntegratedServer {
                         "max-age=0, must-revalidate, no-cache"
                     );
                 }
+
+                if (CACHE.handle(exchange)) {
+                    return;
+                }
+
                 resourceHandler.handleRequest(exchange);
             })
             .build();

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/JsonCache.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/JsonCache.java
@@ -64,6 +64,10 @@ public final class JsonCache {
         this.cache.forEach(this::write);
     }
 
+    public void clear() {
+        this.cache.clear();
+    }
+
     private void write(final String path, final String data) {
         try {
             FileUtil.atomicWrite(this.directoryProvider.webDirectory().resolve("." + path), tmp -> Files.writeString(tmp, data));

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/JsonCache.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/httpd/JsonCache.java
@@ -1,0 +1,74 @@
+package xyz.jpenilla.squaremap.common.httpd;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import xyz.jpenilla.squaremap.common.config.Config;
+import xyz.jpenilla.squaremap.common.data.DirectoryProvider;
+import xyz.jpenilla.squaremap.common.util.FileUtil;
+
+@DefaultQualifier(NonNull.class)
+@Singleton
+public final class JsonCache {
+    private final DirectoryProvider directoryProvider;
+    private final Map<String, String> cache = new ConcurrentHashMap<>();
+
+    @Inject
+    private JsonCache(final DirectoryProvider directoryProvider) {
+        this.directoryProvider = directoryProvider;
+    }
+
+    boolean handle(final HttpServerExchange exchange) {
+        final @Nullable String cached = this.cache.get(exchange.getRelativePath());
+        if (cached == null) {
+            return false;
+        }
+
+        exchange.getRequestHeaders().put(
+            Headers.CONTENT_TYPE,
+            "application/json"
+        );
+
+        exchange.getResponseSender().send(cached);
+
+        return true;
+    }
+
+    public void put(final String path, final @Nullable String json) {
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException(path);
+        }
+
+        if (json == null) {
+            this.cache.remove(path);
+            return;
+        }
+
+        this.cache.put(path, json);
+
+        if (Config.FLUSH_JSON_IMMEDIATELY || !Config.HTTPD_ENABLED) {
+            this.write(path, json);
+        }
+    }
+
+    public void flush() {
+        this.cache.forEach(this::write);
+    }
+
+    private void write(final String path, final String data) {
+        try {
+            FileUtil.atomicWrite(this.directoryProvider.webDirectory().resolve("." + path), tmp -> Files.writeString(tmp, data));
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
@@ -94,7 +94,7 @@ public final class UpdatePlayers implements Runnable {
                 if (worldConfig.PLAYER_TRACKER_ENABLED) {
                     playerEntry.put("x", Mth.floor(playerLoc.x()));
                     playerEntry.put("z", Mth.floor(playerLoc.z()));
-                    playerEntry.put("yaw", player.getYHeadRot());
+                    playerEntry.put("yaw", Math.round(player.getYHeadRot()));
                     if (worldConfig.PLAYER_TRACKER_NAMEPLATE_SHOW_ARMOR) {
                         playerEntry.put("armor", armorPoints(player));
                     }


### PR DESCRIPTION
When using the internal web server, we can avoid flushing the json to disk immediately. `settings.internal-webserver.flush-json-immediately` can be set to true to continue writing updates as before.

closes #224