### PR TITLE
Hide players wearing items tagged with MAP_INVISIBILITY_EQUIPMENT

### DIFF
--- a/common/src/main/java/xyz/jpenilla/squaremap/common/config/WorldConfig.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/config/WorldConfig.java
@@ -94,6 +94,7 @@ public final class WorldConfig extends AbstractWorldConfig<Config> {
     public boolean PLAYER_TRACKER_NAMEPLATE_SHOW_HEALTH = true;
     public boolean PLAYER_TRACKER_HIDE_INVISIBLE = true;
     public boolean PLAYER_TRACKER_HIDE_SPECTATORS = true;
+    public boolean PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT = true;
     public boolean PLAYER_TRACKER_USE_DISPLAY_NAME = false;
 
     private void playerTrackerSettings() {
@@ -110,6 +111,7 @@ public final class WorldConfig extends AbstractWorldConfig<Config> {
         this.PLAYER_TRACKER_NAMEPLATE_SHOW_HEALTH = this.getBoolean("player-tracker.nameplate.show-health", this.PLAYER_TRACKER_NAMEPLATE_SHOW_HEALTH);
         this.PLAYER_TRACKER_HIDE_INVISIBLE = this.getBoolean("player-tracker.hide.invisible", this.PLAYER_TRACKER_HIDE_INVISIBLE);
         this.PLAYER_TRACKER_HIDE_SPECTATORS = this.getBoolean("player-tracker.hide.spectators", this.PLAYER_TRACKER_HIDE_SPECTATORS);
+        this.PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT = this.getBoolean("player-tracker.hide.map-invisibility-equipment", this.PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT);
         this.PLAYER_TRACKER_USE_DISPLAY_NAME = this.getBoolean("player-tracker.use-display-names", this.PLAYER_TRACKER_USE_DISPLAY_NAME);
     }
 

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
@@ -11,8 +11,10 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -81,7 +83,7 @@ public final class UpdatePlayers implements Runnable {
                 if (worldConfig.PLAYER_TRACKER_HIDE_INVISIBLE && player.isInvisible()) {
                     return;
                 }
-                if  (worldConfig.PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT && player.getInventory().armor.get(3).is(ItemTags.MAP_INVISIBILITY_EQUIPMENT)) {
+                if (worldConfig.PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT && hasMapInvisibilityItemEquipped(player)) {
                     return;
                 }
                 if (this.playerManager.hidden(player) || this.playerManager.otherwiseHidden(player)) {
@@ -122,5 +124,15 @@ public final class UpdatePlayers implements Runnable {
     private static int armorPoints(final ServerPlayer player) {
         final @Nullable AttributeInstance attribute = player.getAttribute(Attributes.ARMOR);
         return attribute == null ? 0 : (int) attribute.getValue();
+    }
+
+    // Copied from MapItemSavedData#hasMapInvisibilityItemEquipped(Player)
+    private static boolean hasMapInvisibilityItemEquipped(final Player player) {
+        for (final EquipmentSlot slot : EquipmentSlot.values()) {
+            if (slot != EquipmentSlot.MAINHAND && slot != EquipmentSlot.OFFHAND && player.getItemBySlot(slot).is(ItemTags.MAP_INVISIBILITY_EQUIPMENT)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/UpdatePlayers.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -78,6 +79,9 @@ public final class UpdatePlayers implements Runnable {
                     return;
                 }
                 if (worldConfig.PLAYER_TRACKER_HIDE_INVISIBLE && player.isInvisible()) {
+                    return;
+                }
+                if  (worldConfig.PLAYER_TRACKER_HIDE_MAP_INVISIBILITY_EQUIPMENT && player.getInventory().armor.get(3).is(ItemTags.MAP_INVISIBILITY_EQUIPMENT)) {
                     return;
                 }
                 if (this.playerManager.hidden(player) || this.playerManager.otherwiseHidden(player)) {


### PR DESCRIPTION
In 24w39a, a player wearing a carved pumpkin will not appear on maps in-game. This PR adds the same functionality to squaremap.