### PR TITLE
Make PNJ the default map image io backend

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -45,4 +45,6 @@ dependencies {
   api(libs.htmlSanitizerJ10) {
     isTransitive = false // depends on guava, provided by mc at runtime
   }
+
+  implementation(libs.pnj)
 }

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/data/MapWorldInternal.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/data/MapWorldInternal.java
@@ -26,6 +26,7 @@ import xyz.jpenilla.squaremap.common.Logging;
 import xyz.jpenilla.squaremap.common.config.ConfigManager;
 import xyz.jpenilla.squaremap.common.config.WorldAdvanced;
 import xyz.jpenilla.squaremap.common.config.WorldConfig;
+import xyz.jpenilla.squaremap.common.data.image.MapImage;
 import xyz.jpenilla.squaremap.common.layer.SpawnIconLayer;
 import xyz.jpenilla.squaremap.common.layer.WorldBorderLayer;
 import xyz.jpenilla.squaremap.common.task.render.RenderFactory;
@@ -146,7 +147,7 @@ public abstract class MapWorldInternal implements MapWorld {
         return Colors.rgb(state.getMapColor(null, null));
     }
 
-    public void saveImage(final Image image) {
+    public void saveImage(final MapImage image) {
         this.imageIOExecutor.saveImage(image);
     }
 

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/BufferedImageMapImageIO.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/BufferedImageMapImageIO.java
@@ -1,0 +1,59 @@
+package xyz.jpenilla.squaremap.common.data.image;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import xyz.jpenilla.squaremap.common.config.Config;
+
+@DefaultQualifier(NonNull.class)
+public final class BufferedImageMapImageIO implements MapImageIO<BufferedImageMapImageIO.BufferedImageMapImage> {
+    @Override
+    public void save(final BufferedImageMapImage image, final OutputStream out) throws IOException {
+        final ImageWriter writer = ImageIO.getImageWritersByFormatName("png").next();
+        try (final ImageOutputStream imageOutputStream = ImageIO.createImageOutputStream(out)) {
+            writer.setOutput(imageOutputStream);
+            final ImageWriteParam param = writer.getDefaultWriteParam();
+            if (Config.COMPRESS_IMAGES && param.canWriteCompressed()) {
+                param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+                if (param.getCompressionType() == null) {
+                    param.setCompressionType(param.getCompressionTypes()[0]);
+                }
+                param.setCompressionQuality(Config.COMPRESSION_RATIO);
+            }
+            writer.write(null, new IIOImage(image.image(), null, null), param);
+        }
+    }
+
+    @Override
+    public BufferedImageMapImage load(final Path input) throws IOException {
+        final @Nullable BufferedImage read = ImageIO.read(input.toFile());
+        if (read == null) {
+            throw new IOException("Failed to read image file '" + input.toAbsolutePath() + "', ImageIO.read(File) result is null. This means no " +
+                "supported image format was able to read it. The image file may have been malformed or corrupted, it will be overwritten.");
+        }
+        return new BufferedImageMapImage(read);
+    }
+
+    @Override
+    public BufferedImageMapImage newImage() {
+        return new BufferedImageMapImage(
+            new BufferedImage(MapImage.SIZE, MapImage.SIZE, BufferedImage.TYPE_INT_ARGB)
+        );
+    }
+
+    public record BufferedImageMapImage(BufferedImage image) implements MapImageIO.IOMapImage {
+        @Override
+        public void setPixel(final int x, final int y, final int color) {
+            this.image.setRGB(x, y, color);
+        }
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/MapImageIO.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/MapImageIO.java
@@ -1,0 +1,20 @@
+package xyz.jpenilla.squaremap.common.data.image;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+@DefaultQualifier(NonNull.class)
+public interface MapImageIO<I extends MapImageIO.IOMapImage> {
+    void save(I image, OutputStream out) throws IOException;
+
+    I load(Path input) throws IOException;
+
+    I newImage();
+
+    interface IOMapImage {
+        void setPixel(int x, int y, int color);
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/PNJMapImageIO.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/data/image/PNJMapImageIO.java
@@ -1,0 +1,44 @@
+package xyz.jpenilla.squaremap.common.data.image;
+
+import io.github.xfacthd.pnj.api.PNJ;
+import io.github.xfacthd.pnj.api.data.Image;
+import io.github.xfacthd.pnj.api.define.ColorFormat;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+@DefaultQualifier(NonNull.class)
+public final class PNJMapImageIO implements MapImageIO<PNJMapImageIO.PNJMapImage> {
+
+    @Override
+    public void save(final PNJMapImage image, final OutputStream out) throws IOException {
+        PNJ.encode(out, image.image());
+    }
+
+    @Override
+    public PNJMapImage load(final Path input) throws IOException {
+        return new PNJMapImage(PNJ.decode(input));
+    }
+
+    @Override
+    public PNJMapImage newImage() {
+        return new PNJMapImage(
+            new Image(
+                MapImage.SIZE,
+                MapImage.SIZE,
+                ColorFormat.RGB_ALPHA,
+                8,
+                new byte[MapImage.SIZE * MapImage.SIZE * 4]
+            )
+        );
+    }
+
+    public record PNJMapImage(Image image) implements IOMapImage {
+        @Override
+        public void setPixel(int x, int y, int color) {
+            this.image.setPixel(x, y, color, true);
+        }
+    }
+}

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/AbstractRender.java
@@ -35,10 +35,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.api.Pair;
 import xyz.jpenilla.squaremap.common.Logging;
+import xyz.jpenilla.squaremap.common.config.Config;
 import xyz.jpenilla.squaremap.common.config.Messages;
 import xyz.jpenilla.squaremap.common.data.BiomeColors;
 import xyz.jpenilla.squaremap.common.data.ChunkCoordinate;
-import xyz.jpenilla.squaremap.common.data.Image;
+import xyz.jpenilla.squaremap.common.data.image.MapImage;
 import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.data.RegionCoordinate;
 import xyz.jpenilla.squaremap.common.util.ChunkHashMapKey;
@@ -202,7 +203,7 @@ public abstract class AbstractRender implements Runnable {
     }
 
     protected final void mapRegion(final RegionCoordinate region) {
-        final Image image = new Image(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX);
+        final MapImage image = new MapImage(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX, Config.MAP_IMAGE_IO);
         final int startX = region.getChunkX();
         final int startZ = region.getChunkZ();
         final List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -223,7 +224,7 @@ public abstract class AbstractRender implements Runnable {
         }
     }
 
-    protected final CompletableFuture<Void> mapSingleChunk(final Image image, final int chunkX, final int chunkZ) {
+    protected final CompletableFuture<Void> mapSingleChunk(final MapImage image, final int chunkX, final int chunkZ) {
         final CompletableFuture<@Nullable ChunkSnapshot> chunkFuture = this.chunks.snapshot(new ChunkPos(chunkX, chunkZ));
         final CompletableFuture<@Nullable ChunkSnapshot> northChunk = this.chunks.snapshotDirect(new ChunkPos(chunkX, chunkZ - 1));
 
@@ -272,7 +273,7 @@ public abstract class AbstractRender implements Runnable {
         });
     }
 
-    protected final CompletableFuture<Void> mapChunkColumn(final Image image, final int chunkX, final int startChunkZ) {
+    protected final CompletableFuture<Void> mapChunkColumn(final MapImage image, final int chunkX, final int startChunkZ) {
         final List<CompletableFuture<ChunkSnapshot>> futures = new ArrayList<>(33);
 
         final CompletableFuture<@Nullable ChunkSnapshot> aboveChunkFuture = this.chunks.snapshotDirect(new ChunkPos(chunkX, startChunkZ - 1));
@@ -309,7 +310,7 @@ public abstract class AbstractRender implements Runnable {
         });
     }
 
-    private void scanChunk(final Image image, final int[] lastY, final ChunkSnapshot chunk) {
+    private void scanChunk(final MapImage image, final int[] lastY, final ChunkSnapshot chunk) {
         while (this.mapWorld.renderManager().rendersPaused() && this.running()) {
             sleep(500);
         }
@@ -327,7 +328,7 @@ public abstract class AbstractRender implements Runnable {
         }
     }
 
-    private void scanTopRow(final Image image, final int[] lastY, final ChunkSnapshot chunk) {
+    private void scanTopRow(final MapImage image, final int[] lastY, final ChunkSnapshot chunk) {
         final int blockX = chunk.pos().getMinBlockX();
         final int blockZ = chunk.pos().getMinBlockZ();
         for (int x = 0; x < 16; x++) {

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/BackgroundRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/BackgroundRender.java
@@ -16,8 +16,9 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.common.Logging;
+import xyz.jpenilla.squaremap.common.config.Config;
 import xyz.jpenilla.squaremap.common.data.ChunkCoordinate;
-import xyz.jpenilla.squaremap.common.data.Image;
+import xyz.jpenilla.squaremap.common.data.image.MapImage;
 import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.data.RegionCoordinate;
 import xyz.jpenilla.squaremap.common.util.Util;
@@ -58,7 +59,7 @@ public final class BackgroundRender extends AbstractRender {
 
         final Map<RegionCoordinate, List<ChunkCoordinate>> regionChunksMap = chunks.stream().collect(Collectors.groupingBy(ChunkCoordinate::regionCoordinate));
         regionChunksMap.forEach((region, chunksToRenderInRegion) -> {
-            final Image image = new Image(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX);
+            final MapImage image = new MapImage(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX, Config.MAP_IMAGE_IO);
 
             final CompletableFuture<?>[] chunkFutures = chunksToRenderInRegion.stream()
                 .map(coord -> this.mapSingleChunk(image, coord.x(), coord.z()))

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/RadiusRender.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/task/render/RadiusRender.java
@@ -14,9 +14,10 @@ import net.minecraft.core.BlockPos;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import xyz.jpenilla.squaremap.common.Logging;
+import xyz.jpenilla.squaremap.common.config.Config;
 import xyz.jpenilla.squaremap.common.config.Messages;
 import xyz.jpenilla.squaremap.common.data.ChunkCoordinate;
-import xyz.jpenilla.squaremap.common.data.Image;
+import xyz.jpenilla.squaremap.common.data.image.MapImage;
 import xyz.jpenilla.squaremap.common.data.MapWorldInternal;
 import xyz.jpenilla.squaremap.common.data.RegionCoordinate;
 import xyz.jpenilla.squaremap.common.util.Numbers;
@@ -99,7 +100,7 @@ public final class RadiusRender extends AbstractRender {
                 this.mapRegion(region);
                 continue;
             }
-            final Image image = new Image(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX);
+            final MapImage image = new MapImage(region, this.mapWorld.tilesPath(), this.mapWorld.config().ZOOM_MAX, Config.MAP_IMAGE_IO);
             final List<CompletableFuture<Void>> chunkFutures = new ArrayList<>();
             for (final ChunkCoordinate chunkCoord : chunkCoords) {
                 chunkFutures.add(this.mapSingleChunk(image, chunkCoord.x(), chunkCoord.z()));

--- a/common/src/main/java/xyz/jpenilla/squaremap/common/util/ImageIOExecutor.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/util/ImageIOExecutor.java
@@ -8,7 +8,7 @@ import java.util.concurrent.locks.LockSupport;
 import net.minecraft.server.level.ServerLevel;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
-import xyz.jpenilla.squaremap.common.data.Image;
+import xyz.jpenilla.squaremap.common.data.image.MapImage;
 
 @DefaultQualifier(NonNull.class)
 public final class ImageIOExecutor {
@@ -25,14 +25,14 @@ public final class ImageIOExecutor {
     }
 
     /**
-     * Submits a save task for the given {@link Image} instance. If the save queue currently
+     * Submits a save task for the given {@link MapImage} instance. If the save queue currently
      * has {@link #IMAGE_IO_MAX_TASKS} or more tasks queued, this method will block until the queue
      * has less than {@link #IMAGE_IO_MAX_TASKS} tasks. This effectively throttles renders when the
      * save queue falls far behind a render, avoiding a potential memory leak.
      *
-     * @param image {@link Image} instance
+     * @param image {@link MapImage} instance
      */
-    public void saveImage(final Image image) {
+    public void saveImage(final MapImage image) {
         this.submittedTasks.getAndIncrement();
         this.executor.execute(() -> {
             try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,8 @@ cardinalComponentsEntity = { group = "org.ladysnake.cardinal-components-api", na
 
 neoforge = { group = "net.neoforged", name = "neoforge", version.ref = "neoforge" }
 
+pnj = "io.github.xfacthd:pnj:1.2"
+
 # buildSrc
 indraCommon = { group = "net.kyori", name = "indra-common", version.ref = "indra" }
 indraPublishingSonatype = { group = "net.kyori", name = "indra-publishing-sonatype", version.ref = "indra" }


### PR DESCRIPTION
Configs with (effectively) default image io settings will be switched to use PNJ. Otherwise, they will continue to use BufferedImage. Acceptable values for the backend option are `pnj` and `bufferedimage`.

Some basic testing shows that PNJ gives compression near the max setting for BufferedImage while taking less time.

The following results are for rendering the same map twice in a row (after a warmup run) averaged over a couple of runs (time), and for the whole tiles directory for the dimension (size). Time is what was spent in `MapImage#save` on the image io thread as measured by spark (async profiler).

| Description | Size | Time |
|--------|--------|--------|
| PNJ | 724K | 1400ms |
| BufferedImage compress-images=enabled, value=1 | 712K | 2300ms |
| BufferedImage compress-images=disabled | 804K | 950ms | 

Questions to answer before merging:
- Do we want to change the default or just add an option?
  - Typically when users are bottlenecked by image io it's due to disk speed, not encoding/decoding.
  - We may want to run more benchmarks separating encoding/decoding. The above table profiles the entire `MapImage#save` method (which includes encode and decode).
- Do we want to change the config layout to better allow for support of other image formats in the future (i.e. lossless/lossy webp)? Or should we leave that for when other image formats are implemented?