### PR TITLE
Set player head marker size to be fixed size.

### DIFF
--- a/common/src/main/resources/web/css/styles.css
+++ b/common/src/main/resources/web/css/styles.css
@@ -35,6 +35,9 @@ div.leaflet-nameplate-pane div img.head {
   vertical-align: middle;
   margin-right: 6px;
 }
+img.head {
+    height: 16px;
+}
 div.leaflet-nameplate-pane div img.armor,
 div.leaflet-nameplate-pane div img.health {
   display: block;

--- a/common/src/main/resources/web/css/styles.css
+++ b/common/src/main/resources/web/css/styles.css
@@ -36,7 +36,7 @@ div.leaflet-nameplate-pane div img.head {
   margin-right: 6px;
 }
 img.head {
-    height: 16px;
+  height: 16px;
 }
 div.leaflet-nameplate-pane div img.armor,
 div.leaflet-nameplate-pane div img.health {

--- a/common/src/main/resources/web/js/modules/PlayerList.js
+++ b/common/src/main/resources/web/js/modules/PlayerList.js
@@ -35,6 +35,7 @@ class PlayerList {
     }
     addToList(player) {
         const head = document.createElement("img");
+        head.classList.add("head");
         head.src = player.getHeadUrl();
 
         const span = document.createElement("span");


### PR DESCRIPTION
When using a different player head source that outputs player head images that are not 16x16 squaremap will currently display the images at full resolution taking up the the map screen. 
![512x512 playerheads sqmap](https://github.com/user-attachments/assets/0cc689e4-3683-470c-aabf-ca33a34bbe39)
After proposed changes player heads will be 16x16 no matter source size.
![512x512 playerheads fixed size sqmap](https://github.com/user-attachments/assets/baec214d-2099-4aeb-936b-823aec366118)

