### PR TITLE
Rotate player markers in the correct direction when passing due-north orientation

### DIFF
--- a/common/src/main/resources/web/js/addons/RotateMarker.js
+++ b/common/src/main/resources/web/js/addons/RotateMarker.js
@@ -68,7 +68,9 @@
         },
 
         setRotationAngle: function(angle) {
-            this.options.rotationAngle = angle;
+            // Find the closest equivalent angle to avoid an unnecessarily large rotation
+            const delta = ((((angle - this.options.rotationAngle) % 360) + 540) % 360) - 180;
+            this.options.rotationAngle += delta;
             this.update();
             return this;
         },


### PR DESCRIPTION
[Pre-pull request](https://github.com/user-attachments/assets/e3202641-3278-4140-98af-e0fa2dfd7fc6)

When a player rotates so that they pass the "due-north" angle, their angle goes from (e.g.) 359deg to 1deg, and the CSS transform treats this as a full 358-degree counterclockwise rotation. Very mildly annoying!

Instead, by finding the closest _equivalent_ angle, all rotations are as short as they can be.

[2025-01-10 20-49-58.webm](https://github.com/user-attachments/assets/e84cfbc2-5a24-4b15-9746-6e31d6b7fc7a)

Logic credit: https://stackoverflow.com/a/53416030