### PR TITLE
Add `static` option to reduce web requests on non-changing maps

### DIFF
--- a/common/src/main/resources/web/js/modules/PlayerList.js
+++ b/common/src/main/resources/web/js/modules/PlayerList.js
@@ -11,7 +11,7 @@ class PlayerList {
         P.map.createPane("nameplate").style.zIndex = 1000;
     }
     tick() {
-        if (P.tick_count % P.worldList.curWorld.player_tracker.update_interval == 0) {
+        if ((!P.staticMode || this.firstTick) && P.tick_count % P.worldList.curWorld.player_tracker.update_interval == 0) {
             P.getJSON("tiles/players.json", (json) => {
                 this.updatePlayerList(json.players);
                 const title = `${this.label}`

--- a/common/src/main/resources/web/js/modules/PlayerList.js
+++ b/common/src/main/resources/web/js/modules/PlayerList.js
@@ -28,14 +28,16 @@ class PlayerList {
             });
         }
 
-        if (P.staticMode) {
-            if (this.jsonCache === null) {
-                fetchPlayers(() => update());
+        if (P.tick_count % P.worldList.curWorld.player_tracker.update_interval == 0) {
+            if (P.staticMode) {
+                if (this.jsonCache === null) {
+                    fetchPlayers(() => update());
+                } else {
+                    update();
+                }
             } else {
-                update();
+                fetchPlayers(() => update());
             }
-        } else if (P.tick_count % P.worldList.curWorld.player_tracker.update_interval == 0) {
-            fetchPlayers(() => update());
         }
     }
     showPlayer(uuid) {

--- a/common/src/main/resources/web/js/modules/PlayerList.js
+++ b/common/src/main/resources/web/js/modules/PlayerList.js
@@ -21,21 +21,21 @@ class PlayerList {
                 P.sidebar.players.legend.innerHTML = title;
             }
         }
-        const fetchPlayers = () => {
+        const fetchPlayers = (callback) => {
             P.getJSON("tiles/players.json", (json) => {
                 this.jsonCache = json;
-                update();
+                callback();
             });
         }
 
         if (P.staticMode) {
             if (this.jsonCache === null) {
-                fetchPlayers();
+                fetchPlayers(() => update());
+            } else {
+                update();
             }
-            update();
         } else if (P.tick_count % P.worldList.curWorld.player_tracker.update_interval == 0) {
-            fetchPlayers();
-            update();
+            fetchPlayers(() => update());
         }
     }
     showPlayer(uuid) {

--- a/common/src/main/resources/web/js/modules/Squaremap.js
+++ b/common/src/main/resources/web/js/modules/Squaremap.js
@@ -50,6 +50,7 @@ class SquaremapMap {
         this.getJSON("tiles/settings.json", (json) => {
             this.layerControl.init();
 
+            this.staticMode = json.static || false;
             this.title = json.ui.title;
             this.sidebar = new Sidebar(json.ui.sidebar, this.getUrlParam("show_sidebar", "true") === "true");
             this.playerList = new PlayerList(json.ui.sidebar);

--- a/common/src/main/resources/web/js/modules/util/Player.js
+++ b/common/src/main/resources/web/js/modules/util/Player.js
@@ -77,15 +77,21 @@ class Player {
         if (displayName.innerText !== this.displayName) {
             displayName.innerText = this.displayName;
         }
-        if (head.src !== this.getHeadUrl()) {
-            head.src = this.getHeadUrl();
+
+        // Only update the src if it's different
+        const headSrc = this.getHeadUrl();
+        const currentHeadSrc = head.src.split('/').pop();
+        if (currentHeadSrc !== headSrc.split('/').pop()) {
+            head.src = headSrc;
         }
         const healthSrc = `images/health/${Math.min(Math.max(player.health, 0), 20)}.png`;
-        if (health.src !== healthSrc) {
+        const currentHealthSrc = health.src.split('/').pop();
+        if (currentHealthSrc !== healthSrc.split('/').pop()) {
             health.src = healthSrc;
         }
         const armorSrc = `images/armor/${Math.min(Math.max(player.armor, 0), 20)}.png`;
-        if (armor.src !== armorSrc) {
+        const currentArmorSrc = armor.src.split('/').pop();
+        if (currentArmorSrc !== armorSrc.split('/').pop()) {
             armor.src = armorSrc;
         }
     }

--- a/common/src/main/resources/web/js/modules/util/Player.js
+++ b/common/src/main/resources/web/js/modules/util/Player.js
@@ -14,7 +14,8 @@ class Player {
             permanent: true,
             direction: "right",
             offset: [10, 0],
-            pane: "nameplate"
+            pane: "nameplate",
+            content: this.makeNameplateContent(json),
         });
         this.marker = L.marker(P.toLatLng(json.x, json.z), {
             icon: L.icon({
@@ -35,7 +36,8 @@ class Player {
             .replace(/{uuid}/g, this.uuid)
             .replace(/{name}/g, this.name);
     }
-    updateNameplate(player) {
+    makeNameplateContent(player) {
+        const ul = document.createElement("ul");
         let headImg = "";
         let armorImg = "";
         let healthImg = "";
@@ -48,7 +50,44 @@ class Player {
         if (P.worldList.curWorld.player_tracker.nameplates.show_health && player.health != null) {
             healthImg = `<img src="images/health/${Math.min(Math.max(player.health, 0), 20)}.png" class="health" />`;
         }
-        this.tooltip.setContent(`<ul><li>${headImg}</li><li>${this.displayName}${healthImg}${armorImg}</li>`);
+        ul.innerHTML = `<li>${headImg}</li><li><span class="display-name">${this.displayName}</span>${healthImg}${armorImg}</li>`;
+        return ul;
+    }
+    setNameplateContent(player) {
+        this.tooltip.setContent(this.makeNameplateContent(player));
+    }
+    updateNameplate(player) {
+        const head = this.tooltip.getContent().querySelectorAll(".head")[0];
+        if (!head && P.worldList.curWorld.player_tracker.nameplates.show_heads) {
+            this.setNameplateContent(player);
+            return;
+        }
+        const armor = this.tooltip.getContent().querySelectorAll(".armor")[0];
+        if (!armor && P.worldList.curWorld.player_tracker.nameplates.show_armor && player.armor != null) {
+            this.setNameplateContent(player);
+            return;
+        }
+        const health = this.tooltip.getContent().querySelectorAll(".health")[0];
+        if (!health && P.worldList.curWorld.player_tracker.nameplates.show_health && player.health != null) {
+            this.setNameplateContent(player);
+            return;
+        }
+        const displayName = this.tooltip.getContent().querySelectorAll(".display-name")[0];
+
+        if (displayName.innerText !== this.displayName) {
+            displayName.innerText = this.displayName;
+        }
+        if (head.src !== this.getHeadUrl()) {
+            head.src = this.getHeadUrl();
+        }
+        const healthSrc = `images/health/${Math.min(Math.max(player.health, 0), 20)}.png`;
+        if (health.src !== healthSrc) {
+            health.src = healthSrc;
+        }
+        const armorSrc = `images/armor/${Math.min(Math.max(player.armor, 0), 20)}.png`;
+        if (armor.src !== armorSrc) {
+            armor.src = armorSrc;
+        }
     }
     update(player) {
         this.x = player.x;

--- a/common/src/main/resources/web/js/modules/util/World.js
+++ b/common/src/main/resources/web/js/modules/util/World.js
@@ -12,20 +12,28 @@ class World {
         this.player_tracker = {};
         this.marker_update_interval = 5;
         this.tiles_update_interval = 15;
+        this.staticNeedsMarkerTick = false;
     }
     tick() {
         // refresh map tile layer
-        if (P.tick_count % this.tiles_update_interval == 0) {
+        if (!P.staticMode && P.tick_count % this.tiles_update_interval == 0) {
             P.layerControl.updateTileLayer();
         }
         // load and draw markers
-        if (P.tick_count % this.marker_update_interval == 0) {
-            P.getJSON(`tiles/${this.name}/markers.json`, (json) => {
-                if (this === P.worldList.curWorld) {
-                    this.markers(json);
-                }
-            });
+        if (!P.staticMode && P.tick_count % this.marker_update_interval == 0) {
+            this.tickMarkers();
         }
+        if (P.staticMode && this.staticNeedsMarkerTick) {
+            this.tickMarkers();
+            this.staticNeedsMarkerTick = false;
+        }
+    }
+    tickMarkers() {
+        P.getJSON(`tiles/${this.name}/markers.json`, (json) => {
+            if (this === P.worldList.curWorld) {
+                this.markers(json);
+            }
+        });
     }
     unload() {
         P.playerList.clearPlayerMarkers();
@@ -44,6 +52,7 @@ class World {
             this.spawn = json.spawn;
             this.marker_update_interval = json.marker_update_interval;
             this.tiles_update_interval = json.tiles_update_interval;
+            this.staticNeedsMarkerTick = true;
 
             // set the scale for our projection calculations
             P.setScale(this.zoom.max);


### PR DESCRIPTION
This is useful when for example uploading a completed map to Cloudflare Pages (like the demo site)

Also reworks player nameplate updates to avoid flickering on chrome