### PR TITLE
fix: allow scrolling for both fieldsets on sidebar and cap it

### DIFF
--- a/web/src/css/styles.css
+++ b/web/src/css/styles.css
@@ -118,12 +118,12 @@ div.leaflet-control-layers.coordinates {
 #sidebar fieldset#worlds {
     margin: -15px 0 0;
     overflow-y: auto; /* Make the world list scrollable */
-    max-height: 50%;  /* Allow both lists to co-exist in harmony */
+    max-height: 50%; /* Allow both lists to co-exist in harmony */
 }
 #sidebar fieldset#players {
     margin: 10px 0 0;
     overflow-y: auto;
-    max-height: 50%;  /* Allow both lists to co-exist in harmony */
+    max-height: 50%; /* Allow both lists to co-exist in harmony */
 }
 #sidebar fieldset#players::-webkit-scrollbar {
     width: 6px;


### PR DESCRIPTION
When the WorldList exceeds window height, the hidden worlds are not scrollable and all the players are hidden. This fixes that, caps both lists to a max of 50% of the sidebar, and makes the worldlist scrollable. 

Screenshot is my test server with 40+ worlds, showing that it works:
<img width="1397" height="1018" alt="image" src="https://github.com/user-attachments/assets/0af1519d-22e9-4a30-9a2f-813719c11ffa" />
