### PR TITLE
SSL with internal web server

### DIFF
--- a/common/src/main/java/xyz/jpenilla/squaremap/common/config/Messages.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/config/Messages.java
@@ -242,6 +242,10 @@ public final class Messages {
     public static String LOG_INTERNAL_WEB_DISABLED = "Internal webserver is disabled in config.yml";
     @MessageKey("log.internal-web-started")
     public static String LOG_INTERNAL_WEB_STARTED = "Internal webserver running on <bind>:<port>";
+    @MessageKey("log.internal-web-tls-enabled")
+    public static String LOG_INTERNAL_WEB_TLS_ENABLED = "SSL certificate detected, TLS enabled";
+    @MessageKey("log.internal-web-tls-disabled")
+    public static String LOG_INTERNAL_WEB_TLS_DISABLED = "SSL certificate not found, TLS disabled";
     @MessageKey("log.internal-web-stopped")
     public static String LOG_INTERNAL_WEB_STOPPED = "Internal webserver stopped";
 


### PR DESCRIPTION
## Why?

I know there are other methods such as reverse proxy or simply running a different web server but I think this is a simple and intuitive alternative which could make life easier for non-insignificant amount of server owners.

## Drawbacks

Letsencrypt issues certificates for 90 days, and even the longest-lasting certificates are 398 days at most, this number shrinking to 47 days by 2029. Thus, the process of generating a keystore file and placing it into the plugin data directory could need to be automated, perhaps by a bash script, or we could eventually [look into auto-renewal strategies using ACME](https://github.com/porunov/acme_client) and Letsencrypt.

## The following would need to be added to docs/wiki:

In the folder containing your .pem certificates from Letsencrypt or any other provider, run this command:
`openssl pkcs12 -export -in fullchain.pem -inkey privkey.pem -out keystore.p12 -name undertow -password pass:`
to generate `keystore.p12` file, which you can then place in `/plugins/squaremap/` folder and restart the server. Voilà