### PR TITLE
Add Paper 26.2 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ resource-factory-fabric = { id = "xyz.jpenilla.resource-factory-fabric-conventio
 resource-factory-neoforge = { id = "xyz.jpenilla.resource-factory-neoforge-convention", version.ref = "resource-factory" }
 
 [versions]
-minecraft = "26.1.2"
+minecraft = "26.2"
 checkerQual = "3.55.1"
 cloud = "2.0.0"
 cloudMinecraft = "2.0.0-beta.15"
@@ -22,12 +22,12 @@ option = "1.1.0"
 adventurePlatformMod = "6.9.0"
 paperApi = "1.20.2-R0.1-SNAPSHOT"
 bStats = "3.2.1"
-fabricApi = "0.145.4+26.1.2"
+fabricApi = "0.152.1+26.2"
 fabricLoader = "0.19.3"
 cardinalComponents = "8.0.0"
 guice = "7.0.0"
-neoforge = "26.1.2.7-beta"
-neoform = "26.1.2-1"
+neoforge = "26.2.0.1-beta"
+neoform = "26.2-1"
 htmlSanitizer = "20240325.1"
 resource-factory = "1.3.1"
 

--- a/paper/src/main/java/org/incendo/cloud/paper/SquaremapPaperCommandManager.java
+++ b/paper/src/main/java/org/incendo/cloud/paper/SquaremapPaperCommandManager.java
@@ -1,0 +1,121 @@
+package org.incendo.cloud.paper;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.plugin.configuration.PluginMeta;
+import java.util.logging.Level;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.CloudCapability;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.SenderMapper;
+import org.incendo.cloud.SenderMapperHolder;
+import org.incendo.cloud.brigadier.BrigadierManagerHolder;
+import org.incendo.cloud.brigadier.CloudBrigadierManager;
+import org.incendo.cloud.bukkit.BukkitCommandContextKeys;
+import org.incendo.cloud.bukkit.BukkitDefaultCaptionsProvider;
+import org.incendo.cloud.bukkit.CloudBukkitCapabilities;
+import org.incendo.cloud.bukkit.internal.BukkitHelper;
+import org.incendo.cloud.bukkit.parser.location.Location2DParser;
+import org.incendo.cloud.bukkit.parser.selector.SinglePlayerSelectorParser;
+import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.incendo.cloud.internal.CommandRegistrationHandler;
+
+import static org.incendo.cloud.paper.parser.KeyedWorldParser.keyedWorldParser;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class SquaremapPaperCommandManager<C> extends CommandManager<C> implements SenderMapperHolder<CommandSourceStack, C>,
+    PluginMetaHolder, BrigadierManagerHolder<C, CommandSourceStack> {
+    private final Plugin plugin;
+    private final SenderMapper<CommandSourceStack, C> senderMapper;
+
+    public SquaremapPaperCommandManager(
+        final Plugin plugin,
+        final ExecutionCoordinator<C> executionCoordinator,
+        final SenderMapper<CommandSourceStack, C> senderMapper
+    ) {
+        super(executionCoordinator, CommandRegistrationHandler.nullCommandRegistrationHandler());
+        this.plugin = plugin;
+        this.senderMapper = senderMapper;
+
+        this.commandRegistrationHandler(new ModernPaperBrigadier<>(
+            CommandSourceStack.class,
+            this,
+            senderMapper,
+            this::lockRegistration
+        ));
+
+        CloudBukkitCapabilities.CAPABLE.forEach(this::registerCapability);
+        this.registerCapability(CloudCapability.StandardCapabilities.ROOT_COMMAND_DELETION);
+
+        this.registerDefaultExceptionHandlers();
+        this.captionRegistry().registerProvider(new BukkitDefaultCaptionsProvider<>());
+
+        this.registerCommandPreProcessor(ctx -> ctx.commandContext().store(
+            BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER,
+            this.senderMapper.reverse(ctx.commandContext().sender()).getSender()
+        ));
+        this.registerCommandPreProcessor(new PaperCommandPreprocessor<>(
+            this,
+            this.senderMapper,
+            commandSourceStack -> {
+                final Entity executor = commandSourceStack.getExecutor();
+                if (executor != null) {
+                    return executor;
+                }
+                return commandSourceStack.getSender();
+            }
+        ));
+
+        this.parserRegistry()
+            .registerParser(keyedWorldParser())
+            .registerParser(Location2DParser.location2DParser())
+            .registerParser(SinglePlayerSelectorParser.<C>singlePlayerSelectorParser());
+
+        ((ModernPaperBrigadier<CommandSourceStack, C>) this.commandRegistrationHandler()).registerPlugin(plugin);
+        BukkitHelper.ensurePluginEnabledOrEnabling(plugin);
+    }
+
+    @Override
+    public boolean hasPermission(final @NonNull C sender, final @NonNull String permission) {
+        return this.senderMapper.reverse(sender).getSender().hasPermission(permission);
+    }
+
+    @Override
+    public @NonNull SenderMapper<CommandSourceStack, C> senderMapper() {
+        return this.senderMapper;
+    }
+
+    private void registerDefaultExceptionHandlers() {
+        this.registerDefaultExceptionHandlers(
+            triplet -> this.senderMapper.reverse(triplet.first().sender()).getSender().sendMessage(Component.text(
+                triplet.first().formatCaption(triplet.second(), triplet.third()),
+                NamedTextColor.RED
+            )),
+            pair -> this.plugin.getLogger().log(Level.SEVERE, pair.first(), pair.second())
+        );
+    }
+
+    @Override
+    public Plugin owningPlugin() {
+        return this.plugin;
+    }
+
+    @Override
+    public PluginMeta owningPluginMeta() {
+        return this.plugin.getPluginMeta();
+    }
+
+    @Override
+    public boolean hasBrigadierManager() {
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NonNull CloudBrigadierManager<C, ? extends CommandSourceStack> brigadierManager() {
+        return ((BrigadierManagerHolder<C, CommandSourceStack>) this.commandRegistrationHandler()).brigadierManager();
+    }
+}

--- a/paper/src/main/java/xyz/jpenilla/squaremap/paper/command/PaperCommands.java
+++ b/paper/src/main/java/xyz/jpenilla/squaremap/paper/command/PaperCommands.java
@@ -18,7 +18,7 @@ import org.incendo.cloud.bukkit.parser.location.Location2DParser;
 import org.incendo.cloud.bukkit.parser.selector.SinglePlayerSelectorParser;
 import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.execution.ExecutionCoordinator;
-import org.incendo.cloud.paper.PaperCommandManager;
+import org.incendo.cloud.paper.SquaremapPaperCommandManager;
 import org.incendo.cloud.parser.ParserDescriptor;
 import xyz.jpenilla.squaremap.common.command.BrigadierSetup;
 import xyz.jpenilla.squaremap.common.command.Commander;
@@ -45,11 +45,13 @@ public final class PaperCommands implements PlatformCommands {
             commander -> ((PaperCommander) commander).stack()
         );
 
-        final PaperCommandManager<Commander> mgr = PaperCommandManager.builder(senderMapper)
-            .executionCoordinator(ExecutionCoordinator.<Commander>builder()
+        final SquaremapPaperCommandManager<Commander> mgr = new SquaremapPaperCommandManager<>(
+            this.plugin,
+            ExecutionCoordinator.<Commander>builder()
                 .synchronizeExecution(Folia.FOLIA)
-                .build())
-            .buildOnEnable(this.plugin);
+                .build(),
+            senderMapper
+        );
 
         BrigadierSetup.setup(mgr);
 


### PR DESCRIPTION
## Summary

- bump squaremap's target Minecraft/platform versions to 26.2
- replace the Paper command manager construction with a small squaremap-specific Cloud Paper shim
- register only the Bukkit/Paper parsers squaremap uses, avoiding Cloud Bukkit's eager `ItemStackParser` initialization that crashes on Paper 26.2 due to the removed/changed `CraftItemStack.asBukkitCopy(net.minecraft.world.item.ItemStack)` reflection target

## Verification

- `./gradlew --no-daemon :squaremap-paper:compileJava --stacktrace` — BUILD SUCCESSFUL
- `cd web && bun install`; `./gradlew --no-daemon :squaremap-paper:build --stacktrace` — BUILD SUCCESSFUL
- Disposable Paper 26.2 build 10 smoke test with built `squaremap-paper-mc26.2-1.3.14-SNAPSHOT+442231a.jar` — squaremap loaded and server reached `Done`; no `CraftItemStack`, `ItemStackParser`, or enable error appeared in `server.log`

Smoke test used a temporary server directory only; no live server/plugins were touched.