### PR TITLE
Fix Paper runtime crash on 26.2: bump cloud-minecraft to 2.0.0-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ resource-factory-neoforge = { id = "xyz.jpenilla.resource-factory-neoforge-conve
 minecraft = "26.2"
 checkerQual = "3.55.1"
 cloud = "2.0.0"
-cloudMinecraft = "2.0.0-beta.16"
+cloudMinecraft = "2.0.0-SNAPSHOT"
 cloudProcessors = "1.0.0-rc.1"
 cloudModded = "2.0.0-beta.17"
 cloudSponge = "2.0.0-SNAPSHOT"


### PR DESCRIPTION
Paper 26.2 bundles Adventure 5.1.1, which removed the deprecated net.kyori.adventure.text.serializer.plain.PlainComponentSerializer. cloud-minecraft-extras 2.0.0-beta.16 still calls it in RichDescription.textDescription(), so squaremap compiled fine but crashed at runtime during command registration (cloud-paper ModernPaperBrigadier -> BukkitHelper.description) with NoClassDefFoundError, aborting server startup.

The incendo 2.0.0-SNAPSHOT switched RichDescription to PlainTextComponentSerializer (Adventure 5 compatible). The sonatype snapshot repo is already configured in base-conventions. Only affects the Paper command stack (cloud-minecraft bom/brigadier/extras + cloud-paper); fabric/neoforge use cloudModded.

Verified: Paper 26.2 boots to Done, squaremap enables, commands register, and the internal webserver renders/serves tiles.