### PR TITLE
Fix nondeterministic biome downfall lookup

### DIFF
--- a/common/src/main/java/xyz/jpenilla/squaremap/common/data/LevelBiomeColorData.java
+++ b/common/src/main/java/xyz/jpenilla/squaremap/common/data/LevelBiomeColorData.java
@@ -6,10 +6,7 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.nio.file.Path;
-import java.util.Arrays;
 import javax.imageio.ImageIO;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.biome.Biome;
@@ -78,33 +75,17 @@ public record LevelBiomeColorData(
     }
 
     private static float downfall(final Biome biome) {
-        // climateSettings is the first instance field in Biome
-        final Field climateSettingsField = Arrays.stream(biome.getClass().getDeclaredFields())
-            .filter(it -> !Modifier.isStatic(it.getModifiers()))
-            .findFirst()
-            .orElseThrow();
-        climateSettingsField.setAccessible(true);
-        float downfall = Float.MAX_VALUE;
-        // downfall() record accessor is second float returning method on Biome.ClimateSettings
         try {
+            final Field climateSettingsField = biome.getClass().getDeclaredField("climateSettings");
+            climateSettingsField.setAccessible(true);
             final Object climateSettings = climateSettingsField.get(biome);
-            int count = 0;
-            for (final Method m : climateSettings.getClass().getDeclaredMethods()) {
-                if (m.getReturnType() == Float.TYPE) {
-                    count++;
-                    if (count == 2) {
-                        downfall = (float) m.invoke(climateSettings);
-                        break;
-                    }
-                }
-            }
+
+            final Field downfallField = climateSettings.getClass().getDeclaredField("downfall");
+            downfallField.setAccessible(true);
+            return downfallField.getFloat(climateSettings);
         } catch (final ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
-        if (downfall == Float.MAX_VALUE) {
-            throw new IllegalStateException("Could not determine 'downfall' for biome: " + biome);
-        }
-        return downfall;
     }
 
     private static int[] toArray(final BufferedImage image) {


### PR DESCRIPTION
LevelBiomeColorData obtained a biome's downfall by selecting the second
float-returning method from Class#getDeclaredMethods(). This assumed that
Biome.ClimateSettings methods would be returned in declaration order:

  temperature, downfall

However, the getDeclaredMethods documentation states that the returned
elements are not sorted and are not in any particular order.

The ordering workaround was originally used because squaremap's bytecode
was remapped at build time, while names passed to reflection were not.
Selecting fields and methods by their structure and position avoided
having to handle runtime mapping differences between names such as
"temperature"/"downfall" and their obfuscated equivalents "a"/"b".

On HotSpot, methods are internally sorted by the memory addresses of
their method-name Symbols for faster lookup, and getDeclaredMethods
iterates that array. The resulting order depends on which names were
interned first and where their Symbols were allocated.

Common names such as "temperature", or short obfuscated names such as
"a", were much more likely to have already been interned than
"downfall" or "b". The usual startup path therefore strongly favored the
ordering expected by squaremap, making the code appear to follow
declaration order.

The ordering is stable for a JVM lifetime and is not a random 50/50
decision on each invocation. CDS state, mappings, transformed class
constant pools, server implementation, mods, plugins, agents, and
class-loading order can all affect symbol interning. An ordering that is
rare in one environment can consequently become much more likely in
another.

A minimal test on HotSpot reproduced both outcomes solely by changing
which method-name symbol was loaded first:

  preload temperature -> temperature, downfall
  preload downfall    -> downfall, temperature

When the second ordering occurred, squaremap selected temperature instead
of downfall. A savanna temperature of 2 was then clamped to 1 and used as
humidity, rather than using its actual downfall of 0.

This produces the exact colors reported in #290:

  correct grass:     #BFB755
  incorrect grass:   #47CD33
  correct foliage:   #939E23
  incorrect foliage: #16B400

The incorrect values also match the dominant pixels extracted from the
screenshots attached to the issue.

Biome colors are initialized per map world and remain stable afterward.
Tiles rendered under a previous initialization retain their old colors,
while event-triggered background renders gradually replace individual
chunks using the current values. This explains the chunk-aligned color
transitions, full renders making all savanna consistently green, and
tiles later changing back after another map-world initialization.

The game runtime is no longer obfuscated, so read the named
climateSettings and downfall fields directly. This removes the ordering
assumption and makes the lookup independent of HotSpot, OpenJ9, or any
other JVM's getDeclaredMethods implementation.

Fixes #290
